### PR TITLE
Dark mode for the Feedback form AuthorTable component

### DIFF
--- a/src/components/FeedbackForms/SubmitCorrectAbstract/AuthorTable.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/AuthorTable.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import DataTable, { IDataTableColumn } from 'react-data-table-component';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { shallowEqual } from '../../../utils';
-import { Control, ModalButton } from '../components';
+import { Control, ModalButton, Checkbox } from '../components';
 import { Author, SubmitCorrectAbstractFormValues } from '../models';
 
 interface IModifyProps {
@@ -314,6 +314,7 @@ const AuthorTable: React.FC<IAuthorTableProps> = ({ onChange, authors }) => {
           selectableRows
           selectableRowsHighlight
           contextActions={contextActions}
+          selectableRowsComponent={Checkbox}
           onSelectedRowsChange={({ selectedRows }) => setSelected(selectedRows)}
           clearSelectedRows={clearRows}
         />

--- a/src/components/FeedbackForms/components/Checkbox.tsx
+++ b/src/components/FeedbackForms/components/Checkbox.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export type Ref = HTMLInputElement;
+export interface CheckboxProps {
+  onClick: (...event: any[]) => void;
+}
+
+const Checkbox = React.forwardRef<Ref, CheckboxProps>(
+  ({ onClick, ...rest }, ref) => (
+    <label className="custom-checkbox" onClick={onClick}>
+      <input
+        type="checkbox"
+        className="custom-control-input"
+        ref={ref}
+        {...rest}
+      />
+    </label>
+  )
+);
+
+export default Checkbox;

--- a/src/components/FeedbackForms/components/index.ts
+++ b/src/components/FeedbackForms/components/index.ts
@@ -8,3 +8,4 @@ export { default as PreviewModal } from './PreviewModal';
 export { default as RadioControl } from './RadioControl';
 export { default as Recaptcha, RecaptchaMessage } from './Recaptcha';
 export { default as SelectControl } from './SelectControl';
+export { default as Checkbox } from './Checkbox';


### PR DESCRIPTION
This component was missed for the dark mode. 

<img width="980" alt="Screen Shot 2021-05-27 at 4 50 20 PM" src="https://user-images.githubusercontent.com/636361/119910267-a04edb00-bf0b-11eb-99e6-635885adf90a.png">
