### PR TITLE
Remove URL validation for feedback forms

### DIFF
--- a/src/components/FeedbackForms/SubmitCorrectAbstract/SubmitCorrectAbstract.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/SubmitCorrectAbstract.tsx
@@ -54,7 +54,7 @@ const validationSchema: Yup.ObjectSchema<SubmitCorrectAbstractFormValues> = Yup.
     urls: Yup.array(
       Yup.object({
         type: Yup.mixed(),
-        value: Yup.string().url('Not a valid URL'),
+        value: Yup.string(),
       })
     ),
     abstract: Yup.string(),


### PR DESCRIPTION
Remove URL validation, since some URLs in the database are not valid
causing errors.

Specifically: 1997ESASP1200.....E