### PR TITLE
Add confirm to feedback forms

### DIFF
--- a/src/components/FeedbackForms/SubmitCorrectAbstract/AuthorTable.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/AuthorTable.tsx
@@ -380,9 +380,7 @@ interface IAuthorTableProps {
 }
 
 const Wrapper = () => {
-  const { setValue, register } = useFormContext<
-    SubmitCorrectAbstractFormValues
-  >();
+  const { setValue, register } = useFormContext();
 
   React.useEffect(() => {
     register({ name: 'authors' });

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/ConfirmNoAuthorCheckbox.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/ConfirmNoAuthorCheckbox.tsx
@@ -1,0 +1,62 @@
+import React, { FC, useEffect } from 'react';
+import { FormGroup } from 'react-bootstrap';
+import { useFormContext, useWatch } from 'react-hook-form';
+import styled from 'styled-components';
+import { SubmitCorrectAbstractFormValues } from '../models';
+
+interface IConfirmNoAuthorCheckbox {}
+
+export const ConfirmNoAuthorCheckbox: FC<IConfirmNoAuthorCheckbox> = () => {
+  const { control, register, setValue, unregister, errors } = useFormContext();
+
+  const authors = useWatch<SubmitCorrectAbstractFormValues['authors']>({
+    control,
+    name: 'authors',
+  });
+
+  const confirmNoAuthor = useWatch<
+    SubmitCorrectAbstractFormValues['confirmNoAuthor']
+  >({
+    control,
+    name: 'confirmNoAuthor',
+    defaultValue: false,
+  });
+
+  useEffect(() => {
+    register({ name: 'confirmNoAuthor' });
+    return () => unregister('confirmNoAuthor');
+  }, [register]);
+
+  if (!authors || authors.length === 0) {
+    return (
+      <FormGroup
+        className={errors?.confirmNoAuthor ? `has-feedback has-error` : ''}
+      >
+        <Label hasError={errors?.confirmNoAuthor}>
+          <input
+            type="checkbox"
+            name="confirmNoAuthor"
+            checked={confirmNoAuthor}
+            required
+            onChange={(e) =>
+              setValue('confirmNoAuthor', e.currentTarget.checked)
+            }
+            ref={register}
+          />{' '}
+          Abstract has no author(s)?
+        </Label>
+        {errors?.confirmNoAuthor ? (
+          <span className="help-block with-errors">
+            {errors.confirmNoAuthor.message}
+          </span>
+        ) : null}
+      </FormGroup>
+    );
+  }
+  return null;
+};
+
+const Label = styled.label<{ hasError: boolean }>`
+  margin-bottom: 1rem;
+  color: ${(props) => (props.hasError ? '#c7311a' : 'auto')};
+`;

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/RecordForm.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/RecordForm.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { CheckboxControl, Control } from '../components';
 import { collectionOptions, SubmitCorrectAbstractFormValues } from '../models';
 import AuthorTable from './AuthorTable';
+import { ConfirmNoAuthorCheckbox } from './ConfirmNoAuthorCheckbox';
 import KeywordsList from './KeywordsList';
 import ReferencesList from './ReferencesList';
 import UrlsList from './UrlsList';
@@ -36,6 +37,7 @@ const RecordForm: React.FC<IRecordFormProps> = () => {
       />
       <Label>Authors</Label>
       <AuthorTable />
+      <ConfirmNoAuthorCheckbox />
       <Control
         type="text"
         field="publication"

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/SubmitCorrectAbstract.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/SubmitCorrectAbstract.tsx
@@ -62,6 +62,14 @@ const validationSchema: Yup.ObjectSchema<SubmitCorrectAbstractFormValues> = Yup.
     references: Yup.array(Yup.object().shape({ value: Yup.string() })),
     comments: Yup.string().ensure(),
     recaptcha: Yup.string().ensure(),
+    confirmNoAuthor: Yup.boolean().test(
+      'confirmNoAuthor',
+      'Please confirm, this abstract has no author(s)',
+      function(value) {
+        const hasAuthors = this?.parent?.authors?.length > 0;
+        return (value && !hasAuthors) || (!value && hasAuthors);
+      }
+    ),
   }
 );
 
@@ -81,6 +89,7 @@ export const defaultValues: SubmitCorrectAbstractFormValues = {
   references: [{ value: '' }],
   comments: '',
   recaptcha: '',
+  confirmNoAuthor: false,
 };
 
 export interface IOriginContext {
@@ -159,10 +168,6 @@ const SubmitCorrectAbstract: React.FunctionComponent = () => {
     return () => clearTimeout(handle);
   }, [submissionState]);
 
-  const onSubmit = methods.handleSubmit((data) => {
-    console.log('submitted', data);
-  });
-
   return (
     <FormErrorBoundary>
       <FlexView column>
@@ -183,7 +188,7 @@ const SubmitCorrectAbstract: React.FunctionComponent = () => {
           <FormSubmissionCtx.Provider value={submissionValue}>
             <OriginCtx.Provider value={value}>
               <form>
-                <MainForm onSubmit={onSubmit} />
+                <MainForm />
               </form>
             </OriginCtx.Provider>
           </FormSubmissionCtx.Provider>

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/api/fetchFullRecord.ts
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/api/fetchFullRecord.ts
@@ -113,6 +113,7 @@ const fetchFullRecord = _.memoize(
         authors,
         keywords: keywords.map((k) => ({ value: k })),
         urls,
+        confirmNoAuthor: false,
       };
     }
 

--- a/src/components/FeedbackForms/components/FormErrorBoundary.tsx
+++ b/src/components/FeedbackForms/components/FormErrorBoundary.tsx
@@ -18,7 +18,7 @@ class FormErrorBoundary extends React.Component {
     if (this.state.hasError) {
       return (
         <Container>
-          <h1>Sorry! there was an error, please reload the page.</h1>
+          <h4>Sorry! there was an error, please reload the page.</h4>
         </Container>
       );
     }

--- a/src/components/FeedbackForms/models.ts
+++ b/src/components/FeedbackForms/models.ts
@@ -160,4 +160,5 @@ export type SubmitCorrectAbstractFormValues = {
   references: Reference[];
   comments: string;
   recaptcha: string;
+  confirmNoAuthor: boolean;
 };


### PR DESCRIPTION
Adds a `confirmNoAuthors` checkbox to feedback forms.

Checkbox: 
<img width="346" alt="image" src="https://user-images.githubusercontent.com/6970899/214503741-849af7e8-63ca-437a-8001-f12cc8137629.png">

Error:
<img width="341" alt="image" src="https://user-images.githubusercontent.com/6970899/214503829-f0b69976-42c2-4be8-b066-d6f61bcd1ec3.png">

New field in output:
<img width="307" alt="image" src="https://user-images.githubusercontent.com/6970899/214503903-1cd9ad95-b5ab-4d88-b12b-c05d0cdda548.png">
