### PR TITLE
Improvements to feedback form error handling

### DIFF
--- a/src/components/FeedbackForms/AssociatedReferences/AssociatedReferences.tsx
+++ b/src/components/FeedbackForms/AssociatedReferences/AssociatedReferences.tsx
@@ -6,11 +6,7 @@ import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import * as Yup from 'yup';
 import { FormErrorBoundary } from '../components';
-import {
-  AssociatedArticlesFormValues,
-  ReduxState,
-  relationOptions,
-} from '../models';
+import { AssociatedArticlesFormValues, ReduxState, relationOptions } from '../models';
 import MainForm from './MainForm';
 
 const validationSchema: Yup.ObjectSchema<AssociatedArticlesFormValues> = Yup.object().shape(
@@ -21,7 +17,7 @@ const validationSchema: Yup.ObjectSchema<AssociatedArticlesFormValues> = Yup.obj
       .required('Required'),
     relation: Yup.mixed().oneOf(
       relationOptions.map(({ key }) => key),
-      'Must select a relation'
+      'Must select a relation',
     ),
     customRelation: Yup.string().test(
       'customRelationRequired',
@@ -32,7 +28,7 @@ const validationSchema: Yup.ObjectSchema<AssociatedArticlesFormValues> = Yup.obj
           return false;
         }
         return true;
-      }
+      },
     ),
     sourceBibcode: Yup.string()
       .required('Source bibcode is required')
@@ -42,10 +38,10 @@ const validationSchema: Yup.ObjectSchema<AssociatedArticlesFormValues> = Yup.obj
         bibcode: Yup.string()
           .required('Associated bibcode is blank')
           .length(19, 'Invalid Bibcode'),
-      })
+      }),
     ),
     recaptcha: Yup.string().ensure(),
-  }
+  },
 );
 
 export const defaultValues: AssociatedArticlesFormValues = {
@@ -62,7 +58,7 @@ const emailSelector = ({ user }: ReduxState) => user.email;
 
 const AssociatedReferences: React.FunctionComponent = () => {
   const email = useSelector<ReduxState, AssociatedArticlesFormValues['email']>(
-    emailSelector
+    emailSelector,
   );
 
   const methods = useForm<AssociatedArticlesFormValues>({

--- a/src/components/FeedbackForms/AssociatedReferences/BibcodeList.tsx
+++ b/src/components/FeedbackForms/AssociatedReferences/BibcodeList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useFormContext, useFieldArray, useWatch } from 'react-hook-form';
+import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import FlexView from 'react-flexview';
 import PropTypes from 'prop-types';
 import { AssociatedArticlesFormValues } from '../models';
@@ -32,7 +32,7 @@ const BibcodeList: React.FunctionComponent<IBibcodeListProps> = ({
   const getErrorMessage = (
     index: number,
     field: string,
-    innerField: string
+    innerField: string,
   ): string | undefined => {
     return errors?.[field]?.[index]?.[innerField]?.message;
   };
@@ -40,7 +40,7 @@ const BibcodeList: React.FunctionComponent<IBibcodeListProps> = ({
   // get the placeholder based on the type of relation
   const relation = useWatch<AssociatedArticlesFormValues['relation']>({
     name: 'relation',
-    defaultValue: 'none'
+    defaultValue: 'none',
   });
   const placeholder = getBibcodePlaceholder(relation);
 
@@ -114,7 +114,7 @@ BibcodeList.propTypes = {
 };
 
 const getBibcodePlaceholder = (
-  type: AssociatedArticlesFormValues['relation']
+  type: AssociatedArticlesFormValues['relation'],
 ) => {
   switch (type) {
     case 'arxiv':

--- a/src/components/FeedbackForms/AssociatedReferences/FormPreview.tsx
+++ b/src/components/FeedbackForms/AssociatedReferences/FormPreview.tsx
@@ -33,6 +33,7 @@ const submitFeedback = async (data: FeedbackRequest) => {
 interface IFormPreview {
   onSubmit?: () => void;
 }
+
 const FormPreview: React.FunctionComponent<IFormPreview> = ({ onSubmit }) => {
   const { getValues, trigger, setError, reset, setValue } = useFormContext<
     AssociatedArticlesFormValues
@@ -80,7 +81,7 @@ const FormPreview: React.FunctionComponent<IFormPreview> = ({ onSubmit }) => {
         if (diff.includes(sourceBibcode)) {
           setError('sourceBibcode', {
             type: 'validate',
-            message: "Bibcode wasn't found in ADS",
+            message: 'Bibcode wasn\'t found in ADS',
           });
         }
 
@@ -89,7 +90,7 @@ const FormPreview: React.FunctionComponent<IFormPreview> = ({ onSubmit }) => {
           if (diff.includes(bibcode)) {
             setError(`associated[${i}].bibcode`, {
               type: 'validate',
-              message: "Bibcode wasn't found in ADS",
+              message: 'Bibcode wasn\'t found in ADS',
             });
           }
         });
@@ -164,7 +165,7 @@ type FeedbackRequest = {
 };
 
 const createFeedbackString = (
-  props: AssociatedArticlesFormValues
+  props: AssociatedArticlesFormValues,
 ): FeedbackRequest => {
   const {
     name,

--- a/src/components/FeedbackForms/AssociatedReferences/MainForm.tsx
+++ b/src/components/FeedbackForms/AssociatedReferences/MainForm.tsx
@@ -10,6 +10,7 @@ import FormStatus from './FormStatus';
 interface IMainFormProps {
   onSubmit?: () => void;
 }
+
 const MainForm: React.FunctionComponent<IMainFormProps> = ({ onSubmit }) => {
   const { register, errors } = useFormContext<AssociatedArticlesFormValues>();
 

--- a/src/components/FeedbackForms/AssociatedReferences/PreviewBody.tsx
+++ b/src/components/FeedbackForms/AssociatedReferences/PreviewBody.tsx
@@ -4,7 +4,7 @@ import { AssociatedArticlesFormValues, relationOptions } from '../models';
 
 const getMainRelationString = (
   relation: AssociatedArticlesFormValues['relation'],
-  customRelation: AssociatedArticlesFormValues['customRelation']
+  customRelation: AssociatedArticlesFormValues['customRelation'],
 ) => {
   if (relation === 'other') {
     return customRelation;
@@ -18,7 +18,7 @@ const getMainRelationString = (
 };
 
 const getSecondaryRelationString = (
-  relation: AssociatedArticlesFormValues['relation']
+  relation: AssociatedArticlesFormValues['relation'],
 ) => {
   const match = relationOptions.find((o) => o.key === relation);
   if (match) {
@@ -45,7 +45,7 @@ export const generatePreview = ({
   Correlated articles:
 
   ${relationString}${' '.repeat(
-    Math.abs(23 - relationString.length)
+    Math.abs(23 - relationString.length),
   )}${associationString}
   ${preamble}${associated
     .map(({ bibcode }, idx) => {

--- a/src/components/FeedbackForms/MissingIncorrectRecord/BibcodeList.tsx
+++ b/src/components/FeedbackForms/MissingIncorrectRecord/BibcodeList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useFormContext, useFieldArray } from 'react-hook-form';
+import { useFieldArray, useFormContext } from 'react-hook-form';
 import FlexView from 'react-flexview';
 import styled from 'styled-components';
 import { Control } from '../components';
@@ -42,7 +42,7 @@ const BibcodeList: React.FunctionComponent<{}> = () => {
 
   const getErrorMessage = (
     index: number,
-    field: string
+    field: string,
   ): string | undefined => {
     return errors?.bibcodes?.[index]?.[field]?.message;
   };

--- a/src/components/FeedbackForms/MissingIncorrectRecord/FormPreview.tsx
+++ b/src/components/FeedbackForms/MissingIncorrectRecord/FormPreview.tsx
@@ -34,6 +34,7 @@ const submitFeedback = async (data: FeedbackRequest) => {
 interface IFormPreview {
   onSubmit?: () => void;
 }
+
 const FormPreview: React.FunctionComponent<IFormPreview> = ({ onSubmit }) => {
   const { getValues, setError, trigger, reset } = useFormContext<
     MissingIncorrectRecordFormValues
@@ -73,14 +74,14 @@ const FormPreview: React.FunctionComponent<IFormPreview> = ({ onSubmit }) => {
           if (diff.includes(citing.trim())) {
             setError(`bibcodes[${i}].citing`, {
               type: 'validate',
-              message: "Bibcode wasn't found in ADS",
+              message: 'Bibcode wasn\'t found in ADS',
             });
           }
 
           if (diff.includes(cited.trim())) {
             setError(`bibcodes[${i}].cited`, {
               type: 'validate',
-              message: "Bibcode wasn't found in ADS",
+              message: 'Bibcode wasn\'t found in ADS',
             });
           }
         });
@@ -95,7 +96,7 @@ const FormPreview: React.FunctionComponent<IFormPreview> = ({ onSubmit }) => {
       const values = getValues();
       const exportResponse = await fetchReference(values.bibcodes);
       await submitFeedback(
-        createFeedbackString(values, exportResponse?.export.split(/\n/g))
+        createFeedbackString(values, exportResponse?.export.split(/\n/g)),
       );
       if (typeof onSubmit === 'function') {
         onSubmit();
@@ -167,7 +168,7 @@ type FeedbackRequest = {
 
 const createFeedbackString = (
   props: MissingIncorrectRecordFormValues,
-  referenceString: string[]
+  referenceString: string[],
 ): FeedbackRequest => {
   const { name, email, bibcodes, recaptcha } = props;
 

--- a/src/components/FeedbackForms/MissingIncorrectRecord/MainForm.tsx
+++ b/src/components/FeedbackForms/MissingIncorrectRecord/MainForm.tsx
@@ -10,6 +10,7 @@ import FormStatus from './FormStatus';
 interface IMainFormProps {
   onSubmit?: () => void;
 }
+
 const MainForm: React.FunctionComponent<IMainFormProps> = ({ onSubmit }) => {
   const { register, errors } = useFormContext<
     MissingIncorrectRecordFormValues

--- a/src/components/FeedbackForms/MissingIncorrectRecord/MissingIncorrectRecord.tsx
+++ b/src/components/FeedbackForms/MissingIncorrectRecord/MissingIncorrectRecord.tsx
@@ -36,13 +36,13 @@ const validationSchema: Yup.ObjectSchema<MissingIncorrectRecordFormValues> = Yup
               'Bibcode is same as citing',
               function() {
                 return this.parent.citing !== this.parent.cited;
-              }
+              },
             ),
-        })
+        }),
       )
       .ensure(),
     recaptcha: Yup.string().ensure(),
-  }
+  },
 );
 
 const emailSelector = ({ user }: ReduxState) => user.email;

--- a/src/components/FeedbackForms/MissingIncorrectRecord/PreviewBody.tsx
+++ b/src/components/FeedbackForms/MissingIncorrectRecord/PreviewBody.tsx
@@ -10,7 +10,7 @@ const getRef = (bibcode: string, refs: string[]) => refs.find(ref => ref.startsW
 export const generatePreview = (
   { bibcodes, email, name }: MissingIncorrectRecordFormValues,
   data: { export: string },
-  ref: React.Ref<HTMLPreElement>
+  ref: React.Ref<HTMLPreElement>,
 ) => {
   if (data && data.export) {
     const refs = data.export.split(/\n/g);
@@ -29,7 +29,7 @@ ${bibcodes.map((entry, i) => `${i + 1}:${i < 9 ? '  ' : ' '}${entry.citing} -> $
 };
 
 export const fetchReference = (
-  bibcodes: MissingIncorrectRecordFormValues['bibcodes']
+  bibcodes: MissingIncorrectRecordFormValues['bibcodes'],
 ) => {
   return apiFetch({
     target: ApiTarget.EXPORT + 'custom',
@@ -38,9 +38,9 @@ export const fetchReference = (
       contentType: 'application/json',
       data: JSON.stringify({
         bibcode: bibcodes.map((e) => e.cited),
-        format: ['%R (%1l (%Y), %Q)']
-      })
-    }
+        format: ['%R (%1l (%Y), %Q)'],
+      }),
+    },
   });
 };
 

--- a/src/components/FeedbackForms/MissingReferences.tsx
+++ b/src/components/FeedbackForms/MissingReferences.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 
 function MissingReferences() {
   return <div>MissingReferences</div>;

--- a/src/components/FeedbackForms/PreviewDialog.tsx
+++ b/src/components/FeedbackForms/PreviewDialog.tsx
@@ -1,8 +1,8 @@
-import React from "react";
-import PropTypes from "prop-types";
-import { Dialog, DialogType, DialogFooter } from "@fluentui/react/lib/Dialog";
-import { DefaultButton, PrimaryButton } from "@fluentui/react/lib/Button";
-import { mergeStyles, hiddenContentStyle } from "@fluentui/react/lib/Styling";
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Dialog, DialogFooter, DialogType } from '@fluentui/react/lib/Dialog';
+import { DefaultButton, PrimaryButton } from '@fluentui/react/lib/Button';
+import { hiddenContentStyle, mergeStyles } from '@fluentui/react/lib/Styling';
 
 interface IPreviewDialogProps {
   children?: React.ReactNode;
@@ -13,16 +13,17 @@ interface IPreviewDialogProps {
    * @param {Function} closeDialog - callback to close dialog
    */
   onSubmit?(): void;
+
   disabled?: boolean;
 }
 
 const screenReaderOnly = mergeStyles(hiddenContentStyle);
-const labelId = "preview_label";
+const labelId = 'preview_label';
 
 const PreviewDialog: React.FunctionComponent<IPreviewDialogProps> = ({
   children,
   onSubmit,
-  disabled
+  disabled,
 }) => {
   const [hidden, setHidden] = React.useState(true);
 
@@ -41,8 +42,8 @@ const PreviewDialog: React.FunctionComponent<IPreviewDialogProps> = ({
         hidden={hidden}
         dialogContentProps={{
           type: DialogType.normal,
-          title: "Previewing Submission",
-          closeButtonAriaLabel: "Close"
+          title: 'Previewing Submission',
+          closeButtonAriaLabel: 'Close',
         }}
         modalProps={{
           titleAriaId: labelId,
@@ -50,12 +51,12 @@ const PreviewDialog: React.FunctionComponent<IPreviewDialogProps> = ({
           styles: {
             main: {
               selectors: {
-                ["@media (min-width: 480px)"]: {
-                  minWidth: 450
-                }
-              }
-            }
-          }
+                ['@media (min-width: 480px)']: {
+                  minWidth: 450,
+                },
+              },
+            },
+          },
         }}
       >
         {children}
@@ -63,7 +64,7 @@ const PreviewDialog: React.FunctionComponent<IPreviewDialogProps> = ({
           <PrimaryButton
             text="Submit"
             onClick={() => {
-              if (typeof onSubmit === "function") {
+              if (typeof onSubmit === 'function') {
                 onSubmit();
               }
               setHidden(true);
@@ -78,14 +79,15 @@ const PreviewDialog: React.FunctionComponent<IPreviewDialogProps> = ({
 
 PreviewDialog.defaultProps = {
   children: null,
-  onSubmit: () => {},
-  disabled: false
+  onSubmit: () => {
+  },
+  disabled: false,
 };
 
 PreviewDialog.propTypes = {
   children: PropTypes.element,
   onSubmit: PropTypes.func,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
 };
 
 export default PreviewDialog;

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/AuthorTable.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/AuthorTable.tsx
@@ -10,6 +10,7 @@ interface IModifyProps {
   author: Author;
   authors: Author[];
 }
+
 const Modify: React.FC<IModifyProps> = ({ author, onSubmit, authors }) => {
   const initialState = {
     aff: '',
@@ -150,11 +151,13 @@ const OrcidControl = ({
 interface IAddProps {
   onSubmit: (author: Author) => void;
 }
+
 const Add: React.FC<IAddProps> = ({ onSubmit }) => {
   interface AddAuthorType extends Omit<Author, 'name'> {
     firstname: string;
     lastname: string;
   }
+
   const initialState: AddAuthorType = {
     aff: '',
     id: '',
@@ -374,6 +377,7 @@ const AuthorTable: React.FC<IAuthorTableProps> = ({ onChange, authors }) => {
     </>
   );
 };
+
 interface IAuthorTableProps {
   onChange: (...event: any[]) => void;
   authors: Author[];

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/BibcodeLoaderBtn.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/BibcodeLoaderBtn.tsx
@@ -5,11 +5,7 @@ import { useFormContext } from 'react-hook-form';
 import { Control } from '../components';
 import { SubmitCorrectAbstractFormValues } from '../models';
 import { fetchFullRecord, FullRecord } from './api';
-import {
-  defaultValues,
-  IOriginContext,
-  OriginCtx,
-} from './SubmitCorrectAbstract';
+import { defaultValues, IOriginContext, OriginCtx } from './SubmitCorrectAbstract';
 
 interface IBibcodeLoadedBtnProps {
   onLoaded: () => void;
@@ -84,8 +80,8 @@ const BibcodeLoaderBtn: React.FC<IBibcodeLoadedBtnProps> = ({
           errors.bibcode
             ? errors.bibcode.message
             : error
-            ? error.message
-            : undefined
+              ? error.message
+              : undefined
         }
         inputProps={{
           onKeyUp: (e) => e.which === 13 && loadRecord(),

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/ConfirmNoAuthorCheckbox.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/ConfirmNoAuthorCheckbox.tsx
@@ -4,7 +4,8 @@ import { useFormContext, useWatch } from 'react-hook-form';
 import styled from 'styled-components';
 import { SubmitCorrectAbstractFormValues } from '../models';
 
-interface IConfirmNoAuthorCheckbox {}
+interface IConfirmNoAuthorCheckbox {
+}
 
 export const ConfirmNoAuthorCheckbox: FC<IConfirmNoAuthorCheckbox> = () => {
   const { control, register, setValue, unregister, errors } = useFormContext();

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/DiffView.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/DiffView.tsx
@@ -7,6 +7,7 @@ interface IDiffViewProps {
   left: SubmitCorrectAbstractFormValues;
   right: SubmitCorrectAbstractFormValues;
 }
+
 const DiffView: React.FC<IDiffViewProps> = React.memo(
   ({ left, right }) => {
     const leftObj = processTree(left);
@@ -54,7 +55,7 @@ const DiffView: React.FC<IDiffViewProps> = React.memo(
     );
   },
   (prevProps, nextProps) =>
-    JSON.stringify(prevProps) !== JSON.stringify(nextProps)
+    JSON.stringify(prevProps) !== JSON.stringify(nextProps),
 );
 
 interface ITextChangeElementProps {
@@ -62,6 +63,7 @@ interface ITextChangeElementProps {
   changes: Change[];
   right: ProcessedFormValues;
 }
+
 const TextChanges = ({ keyProp, changes, right }: ITextChangeElementProps) => {
   return (
     <>
@@ -86,6 +88,7 @@ interface IArrayChangeElementProps {
   keyProp: string;
   changes: ArrayChange<string>[];
 }
+
 const ArrayChanges = ({ keyProp, changes }: IArrayChangeElementProps) => {
   let i = 0;
   return (
@@ -98,8 +101,8 @@ const ArrayChanges = ({ keyProp, changes }: IArrayChangeElementProps) => {
             ...val,
             ...change.value.map((v, idx) => (
               <Add key={`${keyProp} ${idx + currentCount}`}>{`+ ${idx +
-                currentCount +
-                1} ${v}`}</Add>
+              currentCount +
+              1} ${v}`}</Add>
             )),
           ];
         } else if (change.removed) {
@@ -107,8 +110,8 @@ const ArrayChanges = ({ keyProp, changes }: IArrayChangeElementProps) => {
             ...val,
             ...change.value.map((v, idx) => (
               <Remove key={`${keyProp} ${i + idx}`}>{`- ${i +
-                idx +
-                1} ${v}`}</Remove>
+              idx +
+              1} ${v}`}</Remove>
             )),
           ];
         }
@@ -127,20 +130,20 @@ const Add = styled.p`
   color: green;
   margin: 0;
   display: ${(props: { inline?: boolean }) =>
-    props.inline ? 'inline' : 'block'};
+  props.inline ? 'inline' : 'block'};
 `;
 
 const Remove = styled.p`
   color: red;
   margin: 0;
   display: ${(props: { inline?: boolean }) =>
-    props.inline ? 'inline' : 'block'};
+  props.inline ? 'inline' : 'block'};
 `;
 
 const Text = styled.p`
   margin: 0;
   display: ${(props: { inline?: boolean }) =>
-    props.inline ? 'inline' : 'block'};
+  props.inline ? 'inline' : 'block'};
 `;
 
 const SectionTitle = styled.div`
@@ -168,7 +171,7 @@ export interface ProcessedFormValues {
 }
 
 export const processTree = (
-  obj: SubmitCorrectAbstractFormValues
+  obj: SubmitCorrectAbstractFormValues,
 ): ProcessedFormValues => {
   const {
     name,
@@ -234,7 +237,7 @@ const stringifyArrayChanges = (changes: ArrayChange<string>[]) => {
       // actual change made to multiple entries in a row, they are matched by index, not sequential
 
       out.push(
-        `${index} ${strikeText(entries[i].value)}${entries[i + count].value}`
+        `${index} ${strikeText(entries[i].value)}${entries[i + count].value}`,
       );
       entries[i + count] = {
         count: entries[i + count].count,
@@ -292,7 +295,7 @@ const stringifyWordChanges = (changes: Change[]) => {
 
 export function createDiffString(
   left: SubmitCorrectAbstractFormValues,
-  right: SubmitCorrectAbstractFormValues
+  right: SubmitCorrectAbstractFormValues,
 ) {
   const leftObj = processTree(left);
   const rightObj = processTree(right);
@@ -320,10 +323,10 @@ export function createDiffString(
     return `
   >>>> ${sectionTitle}
   ${
-    isArray
-      ? stringifyArrayChanges(changes as ArrayChange<string>[])
-      : stringifyWordChanges(changes as Change[])
-  }
+      isArray
+        ? stringifyArrayChanges(changes as ArrayChange<string>[])
+        : stringifyWordChanges(changes as Change[])
+    }
   <<<<`;
   });
 

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/FormPreview.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/FormPreview.tsx
@@ -5,11 +5,7 @@ import { PreviewModal } from '../components';
 import { EntryType, SubmitCorrectAbstractFormValues } from '../models';
 import { createDiffString, ProcessedFormValues, processTree } from './DiffView';
 import PreviewBody from './PreviewBody';
-import {
-  defaultValues,
-  FormSubmissionCtx,
-  OriginCtx
-} from './SubmitCorrectAbstract';
+import { defaultValues, FormSubmissionCtx, OriginCtx } from './SubmitCorrectAbstract';
 
 type FeedbackRequest = {
   original: ProcessedFormValues;
@@ -29,8 +25,8 @@ const submitFeedback = async (data: FeedbackRequest) => {
       method: 'POST',
       data: JSON.stringify(data),
       dataType: 'json',
-      contentType: 'application/json; charset=UTF-8'
-    }
+      contentType: 'application/json; charset=UTF-8',
+    },
   });
 };
 
@@ -40,9 +36,9 @@ interface IFormPreview {
 }
 
 const FormPreview: React.FunctionComponent<IFormPreview> = ({
-                                                              onSubmit,
-                                                              disabled = false
-                                                            }) => {
+  onSubmit,
+  disabled = false,
+}) => {
   const { trigger, getValues, reset } = useFormContext<
     SubmitCorrectAbstractFormValues
   >();
@@ -63,7 +59,7 @@ const FormPreview: React.FunctionComponent<IFormPreview> = ({
     if (previewRef.current) {
       const currentValues = {
         ...origin,
-        ...getValues()
+        ...getValues(),
       };
 
       try {
@@ -71,8 +67,8 @@ const FormPreview: React.FunctionComponent<IFormPreview> = ({
           createFeedbackString(
             origin,
             currentValues,
-            getSafeDiff(origin, currentValues)
-          )
+            getSafeDiff(origin, currentValues),
+          ),
         );
         if (typeof onSubmit === 'function') {
           onSubmit();
@@ -85,7 +81,7 @@ const FormPreview: React.FunctionComponent<IFormPreview> = ({
           status: 'error',
           message: e?.responseJSON?.message,
           code: e?.status,
-          changes: getSafeDiff(origin, currentValues)
+          changes: getSafeDiff(origin, currentValues),
         });
       }
     }
@@ -137,7 +133,7 @@ const getSafeDiff = (src: SubmitCorrectAbstractFormValues, curr: SubmitCorrectAb
 const createFeedbackString = (
   original: SubmitCorrectAbstractFormValues,
   current: SubmitCorrectAbstractFormValues,
-  previewText: string
+  previewText: string,
 ): FeedbackRequest => {
   const { name, email, recaptcha, entryType } = current;
   return {
@@ -148,7 +144,7 @@ const createFeedbackString = (
     new: processTree(current),
     name,
     email,
-    diff: entryType === EntryType.Edit ? previewText : ''
+    diff: entryType === EntryType.Edit ? previewText : '',
   };
 };
 

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/FormPreview.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/FormPreview.tsx
@@ -8,7 +8,7 @@ import PreviewBody from './PreviewBody';
 import {
   defaultValues,
   FormSubmissionCtx,
-  OriginCtx,
+  OriginCtx
 } from './SubmitCorrectAbstract';
 
 type FeedbackRequest = {
@@ -29,8 +29,8 @@ const submitFeedback = async (data: FeedbackRequest) => {
       method: 'POST',
       data: JSON.stringify(data),
       dataType: 'json',
-      contentType: 'application/json; charset=UTF-8',
-    },
+      contentType: 'application/json; charset=UTF-8'
+    }
   });
 };
 
@@ -38,10 +38,11 @@ interface IFormPreview {
   onSubmit?: () => void;
   disabled?: boolean;
 }
+
 const FormPreview: React.FunctionComponent<IFormPreview> = ({
-  onSubmit,
-  disabled = false,
-}) => {
+                                                              onSubmit,
+                                                              disabled = false
+                                                            }) => {
   const { trigger, getValues, reset } = useFormContext<
     SubmitCorrectAbstractFormValues
   >();
@@ -62,7 +63,7 @@ const FormPreview: React.FunctionComponent<IFormPreview> = ({
     if (previewRef.current) {
       const currentValues = {
         ...origin,
-        ...getValues(),
+        ...getValues()
       };
 
       try {
@@ -70,7 +71,7 @@ const FormPreview: React.FunctionComponent<IFormPreview> = ({
           createFeedbackString(
             origin,
             currentValues,
-            encodeURIComponent(createDiffString(origin, currentValues))
+            getSafeDiff(origin, currentValues)
           )
         );
         if (typeof onSubmit === 'function') {
@@ -84,7 +85,7 @@ const FormPreview: React.FunctionComponent<IFormPreview> = ({
           status: 'error',
           message: e?.responseJSON?.message,
           code: e?.status,
-          changes: encodeURIComponent(createDiffString(origin, currentValues)),
+          changes: getSafeDiff(origin, currentValues)
         });
       }
     }
@@ -124,7 +125,15 @@ const FormPreview: React.FunctionComponent<IFormPreview> = ({
   );
 };
 
-declare var _: any;
+
+const getSafeDiff = (src: SubmitCorrectAbstractFormValues, curr: SubmitCorrectAbstractFormValues) => {
+  try {
+    return encodeURIComponent(createDiffString(src, curr));
+  } catch (e) {
+    return 'Unable to generate diff';
+  }
+};
+
 const createFeedbackString = (
   original: SubmitCorrectAbstractFormValues,
   current: SubmitCorrectAbstractFormValues,
@@ -139,7 +148,7 @@ const createFeedbackString = (
     new: processTree(current),
     name,
     email,
-    diff: entryType === EntryType.Edit ? previewText : '',
+    diff: entryType === EntryType.Edit ? previewText : ''
   };
 };
 

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/FormStatus.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/FormStatus.tsx
@@ -33,7 +33,7 @@ const FormStatus: React.FunctionComponent = () => {
   }
 
   if (submissionState?.status === 'error') {
-    if (submissionState.code === 500 || submissionState.code === 404) {
+    if (submissionState.code === 500 || submissionState.code >= 400 && submissionState.code <= 499) {
       return (
         <div className="alert alert-warning" style={{ marginTop: '1rem' }}>
           There was an error processing the request, please try again, or send

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/KeywordsList.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/KeywordsList.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import { useFormContext, useFieldArray } from 'react-hook-form';
+import { useFieldArray, useFormContext } from 'react-hook-form';
 import FlexView from 'react-flexview';
 import styled from 'styled-components';
 import { Control } from '../components';
-import { SubmitCorrectAbstractFormValues, Keyword } from '../models';
+import { Keyword, SubmitCorrectAbstractFormValues } from '../models';
 
 interface IControlRow {
   count: number;
 }
+
 const ControlRow = styled.div<IControlRow>`
   display: flex;
   & > * {
@@ -52,7 +53,7 @@ const KeywordsList: React.FC = () => {
       }
       return;
     },
-    [errors]
+    [errors],
   );
 
   return (

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/MainForm.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/MainForm.tsx
@@ -6,7 +6,7 @@ import { Control, RadioControl } from '../components';
 import {
   EntryType,
   entryTypeOptions,
-  SubmitCorrectAbstractFormValues,
+  SubmitCorrectAbstractFormValues
 } from '../models';
 import BibcodeLoaderBtn from './BibcodeLoaderBtn';
 import FormPreview from './FormPreview';
@@ -16,6 +16,7 @@ import RecordForm from './RecordForm';
 interface IMainFormProps {
   onSubmit?: () => void;
 }
+
 const MainForm: React.FunctionComponent<IMainFormProps> = ({ onSubmit }) => {
   const { register, errors, control } = useFormContext<
     SubmitCorrectAbstractFormValues
@@ -24,11 +25,12 @@ const MainForm: React.FunctionComponent<IMainFormProps> = ({ onSubmit }) => {
   const [isLoaded, setIsLoaded] = React.useState(false);
   const entryType = useWatch<SubmitCorrectAbstractFormValues['entryType']>({
     control,
-    name: 'entryType',
+    name: 'entryType'
   });
 
   return (
     <React.Fragment>
+      <FormStatus />
       <FlexView column>
         <Control
           type="text"
@@ -76,12 +78,14 @@ const MainForm: React.FunctionComponent<IMainFormProps> = ({ onSubmit }) => {
 
 interface INewEditRadiosProps {
   onChange(value: string): void;
+
   defaultValue: string;
 }
+
 const NewEditRadios: React.FC<INewEditRadiosProps> = ({
-  onChange,
-  defaultValue,
-}) => {
+                                                        onChange,
+                                                        defaultValue
+                                                      }) => {
   const [val, setVal] = React.useState(defaultValue);
   const handleChange = React.useCallback(
     (e: React.FormEvent<HTMLInputElement>) => {
@@ -98,7 +102,7 @@ const NewEditRadios: React.FC<INewEditRadiosProps> = ({
     <div
       role="radio-group"
       className="form-group"
-      aria-aria-labelledby="feedback-entry-type"
+      aria-labelledby="feedback-entry-type"
     >
       <RadioTitle id="feedback-entry-type">Record Type</RadioTitle>
       <label className="radio-inline">
@@ -125,7 +129,7 @@ const NewEditRadios: React.FC<INewEditRadiosProps> = ({
 
 NewEditRadios.defaultProps = {
   onChange: () => null,
-  defaultValue: 'new',
+  defaultValue: 'new'
 };
 
 const RadioTitle = styled.h3`

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/MainForm.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/MainForm.tsx
@@ -3,11 +3,7 @@ import FlexView from 'react-flexview';
 import { useFormContext, useWatch } from 'react-hook-form';
 import styled from 'styled-components';
 import { Control, RadioControl } from '../components';
-import {
-  EntryType,
-  entryTypeOptions,
-  SubmitCorrectAbstractFormValues
-} from '../models';
+import { EntryType, entryTypeOptions, SubmitCorrectAbstractFormValues } from '../models';
 import BibcodeLoaderBtn from './BibcodeLoaderBtn';
 import FormPreview from './FormPreview';
 import FormStatus from './FormStatus';
@@ -25,7 +21,7 @@ const MainForm: React.FunctionComponent<IMainFormProps> = ({ onSubmit }) => {
   const [isLoaded, setIsLoaded] = React.useState(false);
   const entryType = useWatch<SubmitCorrectAbstractFormValues['entryType']>({
     control,
-    name: 'entryType'
+    name: 'entryType',
   });
 
   return (
@@ -83,15 +79,15 @@ interface INewEditRadiosProps {
 }
 
 const NewEditRadios: React.FC<INewEditRadiosProps> = ({
-                                                        onChange,
-                                                        defaultValue
-                                                      }) => {
+  onChange,
+  defaultValue,
+}) => {
   const [val, setVal] = React.useState(defaultValue);
   const handleChange = React.useCallback(
     (e: React.FormEvent<HTMLInputElement>) => {
       setVal(e.currentTarget.name);
     },
-    []
+    [],
   );
 
   React.useEffect(() => {
@@ -129,7 +125,7 @@ const NewEditRadios: React.FC<INewEditRadiosProps> = ({
 
 NewEditRadios.defaultProps = {
   onChange: () => null,
-  defaultValue: 'new'
+  defaultValue: 'new',
 };
 
 const RadioTitle = styled.h3`

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/ObjectsList.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/ObjectsList.tsx
@@ -8,6 +8,7 @@ import { SubmitCorrectAbstractFormValues } from '../models';
 interface IControlRow {
   count: number;
 }
+
 const ControlRow = styled.div<IControlRow>`
   display: flex;
   & > * {
@@ -52,7 +53,7 @@ const KeywordsList: React.FC = () => {
       }
       return;
     },
-    [errors]
+    [errors],
   );
 
   return (

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/PreviewBody.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/PreviewBody.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { EntryType, SubmitCorrectAbstractFormValues } from '../models';
 import DiffView, { processTree } from './DiffView';
 import { OriginCtx } from './SubmitCorrectAbstract';
+import { FormErrorBoundary } from '../components';
 
 const PreviewBody = React.forwardRef<HTMLDivElement>((_, ref) => {
   const { getValues } = useFormContext<SubmitCorrectAbstractFormValues>();
@@ -12,7 +13,7 @@ const PreviewBody = React.forwardRef<HTMLDivElement>((_, ref) => {
   // make sure that undefined values get filled by the original
   const currentValues = {
     ...origin,
-    ...getValues(),
+    ...getValues()
   };
   const { name, email, entryType } = currentValues;
 
@@ -33,14 +34,19 @@ New Record:
       {entryType === EntryType.Edit && (
         <>
           <p>Summary of corrections/updates:</p>
-          <ScrollView>
-            <DiffView left={origin} right={currentValues} />
-          </ScrollView>
+          <FormErrorBoundary msg={<>Unable to load preview. You can still submit.</>}>
+            <ScrollView>
+              <DiffView left={origin} right={currentValues} />
+            </ScrollView>
+          </FormErrorBoundary>
         </>
       )}
+
+
     </div>
   );
 });
+
 
 const ScrollView = styled.div`
   max-height: 600px;

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/PreviewBody.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/PreviewBody.tsx
@@ -13,7 +13,7 @@ const PreviewBody = React.forwardRef<HTMLDivElement>((_, ref) => {
   // make sure that undefined values get filled by the original
   const currentValues = {
     ...origin,
-    ...getValues()
+    ...getValues(),
   };
   const { name, email, entryType } = currentValues;
 

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/RecordForm.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/RecordForm.tsx
@@ -12,6 +12,7 @@ import UrlsList from './UrlsList';
 export interface IRecordFormProps {
   edit?: boolean;
 }
+
 const RecordForm: React.FC<IRecordFormProps> = () => {
   const { register, errors } = useFormContext<
     SubmitCorrectAbstractFormValues

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/ReferencesList.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/ReferencesList.tsx
@@ -3,16 +3,12 @@ import FlexView from 'react-flexview';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import styled from 'styled-components';
 import { Control, SelectControl } from '../components';
-import {
-  EntryType,
-  Reference,
-  referenceOptions,
-  SubmitCorrectAbstractFormValues,
-} from '../models';
+import { EntryType, Reference, referenceOptions, SubmitCorrectAbstractFormValues } from '../models';
 
 interface IControlRow {
   count: number;
 }
+
 const ControlRow = styled.div<IControlRow>`
   display: flex;
   justify-content: flex-start;
@@ -67,7 +63,7 @@ const ReferencesList: React.FC = () => {
       }
       return;
     },
-    [errors]
+    [errors],
   );
 
   return (

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/SubmitCorrectAbstract.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/SubmitCorrectAbstract.tsx
@@ -7,12 +7,7 @@ import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import * as Yup from 'yup';
 import { FormErrorBoundary } from '../components';
-import {
-  Collection,
-  EntryType,
-  ReduxState,
-  SubmitCorrectAbstractFormValues,
-} from '../models';
+import { Collection, EntryType, ReduxState, SubmitCorrectAbstractFormValues } from '../models';
 import MainForm from './MainForm';
 
 const Heading = styled.h2`
@@ -36,7 +31,7 @@ const validationSchema: Yup.ObjectSchema<SubmitCorrectAbstractFormValues> = Yup.
         name: Yup.string(),
         aff: Yup.string(),
         orcid: Yup.string(),
-      })
+      }),
     ),
     publication: Yup.string().required('Publication information is required'),
     publicationDate: Yup.string()
@@ -47,15 +42,15 @@ const validationSchema: Yup.ObjectSchema<SubmitCorrectAbstractFormValues> = Yup.
           moment(
             value,
             ['YYYY-MM', 'YYYY-MM-DD', 'YYYY-00', 'YYYY-00-00', 'YYYY-MM-00'],
-            true
-          ).isValid()
+            true,
+          ).isValid(),
       )
       .required('Publication date is required'),
     urls: Yup.array(
       Yup.object({
         type: Yup.mixed(),
         value: Yup.string(),
-      })
+      }),
     ),
     abstract: Yup.string(),
     keywords: Yup.array(Yup.object().shape({ value: Yup.string() })),
@@ -68,9 +63,9 @@ const validationSchema: Yup.ObjectSchema<SubmitCorrectAbstractFormValues> = Yup.
       function(value) {
         const hasAuthors = this?.parent?.authors?.length > 0;
         return (value && !hasAuthors) || (!value && hasAuthors);
-      }
+      },
     ),
-  }
+  },
 );
 
 export const defaultValues: SubmitCorrectAbstractFormValues = {
@@ -96,6 +91,7 @@ export interface IOriginContext {
   origin: SubmitCorrectAbstractFormValues;
   setOrigin: (values: SubmitCorrectAbstractFormValues) => void;
 }
+
 export const OriginCtx = React.createContext<IOriginContext>({
   origin: defaultValues,
   setOrigin: () => null,
@@ -106,10 +102,12 @@ export type SubmissionState =
   | { status: 'error'; message: string; code: number; changes: string }
   | { status: 'success' }
   | null;
+
 export interface IFormSubmissionCtx {
   submissionState: SubmissionState;
   setSubmissionState: (state: SubmissionState) => void;
 }
+
 export const FormSubmissionCtx = React.createContext<IFormSubmissionCtx>({
   submissionState: null,
   setSubmissionState: () => null,
@@ -143,16 +141,16 @@ const SubmitCorrectAbstract: React.FunctionComponent = () => {
   });
 
   const [origin, setOrigin] = React.useState<SubmitCorrectAbstractFormValues>(
-    initialValues
+    initialValues,
   );
   const value = React.useMemo(() => ({ origin, setOrigin }), [origin]);
 
   const [submissionState, setSubmissionState] = React.useState<SubmissionState>(
-    null
+    null,
   );
   const submissionValue = React.useMemo(
     () => ({ submissionState, setSubmissionState }),
-    [submissionState]
+    [submissionState],
   );
 
   // reset submission state
@@ -162,7 +160,7 @@ const SubmitCorrectAbstract: React.FunctionComponent = () => {
       handle = setTimeout(
         setSubmissionState,
         submissionState.status === 'success' ? 3000 : 10000,
-        null
+        null,
       );
     }
     return () => clearTimeout(handle);

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/UrlsList.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/UrlsList.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { useFormContext, useFieldArray } from 'react-hook-form';
+import { useFieldArray, useFormContext } from 'react-hook-form';
 import FlexView from 'react-flexview';
 import styled from 'styled-components';
-import { urlOptions, SubmitCorrectAbstractFormValues, Url } from '../models';
+import { SubmitCorrectAbstractFormValues, Url, urlOptions } from '../models';
 import { Control, SelectControl } from '../components';
 
 const ControlRow = styled.div`
@@ -56,7 +56,7 @@ const UrlsList: React.FC = () => {
       }
       return;
     },
-    [errors]
+    [errors],
   );
 
   return (

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/api/fetchFullRecord.ts
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/api/fetchFullRecord.ts
@@ -20,7 +20,7 @@ const SKIP_URLS = [
   'http://www.cfa.harvard.edu/sao',
   'https://www.cfa.harvard.edu/',
   'http://www.si.edu',
-  'http://www.nasa.gov',
+  'http://www.nasa.gov'
 ];
 
 /**
@@ -35,7 +35,7 @@ const getUrls = async (identifier: string): Promise<Url[]> => {
   // url regex, skip internal links
   const reg = /href="(https?:\/\/[^"]*)"/gi;
   try {
-    const body = await fetch(`link_gateway/${identifier}/ESOURCE`);
+    const body = await fetch(`link_gateway/${encodeURIComponent(identifier)}/ESOURCE`);
     const raw = await body.text();
     if (raw) {
       return (
@@ -46,11 +46,11 @@ const getUrls = async (identifier: string): Promise<Url[]> => {
               type: e[1].includes('arxiv')
                 ? 'arxiv'
                 : e[1].includes('pdf')
-                ? 'pdf'
-                : e[1].includes('doi')
-                ? 'doi'
-                : 'html',
-              value: e[1],
+                  ? 'pdf'
+                  : e[1].includes('doi')
+                    ? 'doi'
+                    : 'html',
+              value: e[1]
             } as Url)
         )
           .slice(1)
@@ -77,8 +77,8 @@ const fetchFullRecord = _.memoize(
         fl:
           'title,author,aff,pub_raw,pubdate,abstract,volume,bibcode,keyword,orcid_pub',
         q: `identifier:${identifier}`,
-        rows: 1,
-      },
+        rows: 1
+      }
     });
 
     const urls = await getUrls(identifier);
@@ -93,7 +93,7 @@ const fetchFullRecord = _.memoize(
         keyword: keywords = [],
         author = [],
         aff = [],
-        orcid_pub = [],
+        orcid_pub = []
       } = response.response.docs[0];
 
       const authors = author.map((name, position) => ({
@@ -101,7 +101,7 @@ const fetchFullRecord = _.memoize(
         position,
         name,
         aff: aff[position] !== '-' ? aff[position] : '',
-        orcid: orcid_pub[position] !== '-' ? orcid_pub[position] : '',
+        orcid: orcid_pub[position] !== '-' ? orcid_pub[position] : ''
       }));
 
       return {
@@ -113,7 +113,7 @@ const fetchFullRecord = _.memoize(
         authors,
         keywords: keywords.map((k) => ({ value: k })),
         urls,
-        confirmNoAuthor: false,
+        confirmNoAuthor: false
       };
     }
 

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/api/fetchFullRecord.ts
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/api/fetchFullRecord.ts
@@ -20,7 +20,7 @@ const SKIP_URLS = [
   'http://www.cfa.harvard.edu/sao',
   'https://www.cfa.harvard.edu/',
   'http://www.si.edu',
-  'http://www.nasa.gov'
+  'http://www.nasa.gov',
 ];
 
 /**
@@ -50,8 +50,8 @@ const getUrls = async (identifier: string): Promise<Url[]> => {
                   : e[1].includes('doi')
                     ? 'doi'
                     : 'html',
-              value: e[1]
-            } as Url)
+              value: e[1],
+            } as Url),
         )
           .slice(1)
 
@@ -77,8 +77,8 @@ const fetchFullRecord = _.memoize(
         fl:
           'title,author,aff,pub_raw,pubdate,abstract,volume,bibcode,keyword,orcid_pub',
         q: `identifier:${identifier}`,
-        rows: 1
-      }
+        rows: 1,
+      },
     });
 
     const urls = await getUrls(identifier);
@@ -93,7 +93,7 @@ const fetchFullRecord = _.memoize(
         keyword: keywords = [],
         author = [],
         aff = [],
-        orcid_pub = []
+        orcid_pub = [],
       } = response.response.docs[0];
 
       const authors = author.map((name, position) => ({
@@ -101,7 +101,7 @@ const fetchFullRecord = _.memoize(
         position,
         name,
         aff: aff[position] !== '-' ? aff[position] : '',
-        orcid: orcid_pub[position] !== '-' ? orcid_pub[position] : ''
+        orcid: orcid_pub[position] !== '-' ? orcid_pub[position] : '',
       }));
 
       return {
@@ -113,12 +113,12 @@ const fetchFullRecord = _.memoize(
         authors,
         keywords: keywords.map((k) => ({ value: k })),
         urls,
-        confirmNoAuthor: false
+        confirmNoAuthor: false,
       };
     }
 
     throw new Error('No Result for this bibcode');
-  }
+  },
 );
 
 export default fetchFullRecord;

--- a/src/components/FeedbackForms/api.ts
+++ b/src/components/FeedbackForms/api.ts
@@ -37,6 +37,7 @@ interface IApiFetchProps {
   target: string;
   query?: Query;
 }
+
 export const apiFetch = (props: IApiFetchProps) => {
   const { options, target, query } = props;
 
@@ -102,7 +103,7 @@ export enum ApiTarget {
   CHANGE_EMAIL = 'accounts/change-email',
   RECOMMENDER = 'recommender',
   GRAPHICS = 'graphics',
-  FEEDBACK = "feedback/userfeedback",
+  FEEDBACK = 'feedback/userfeedback',
   LIBRARY_IMPORT_CLASSIC_AUTH = 'harbour/auth/classic',
   LIBRARY_IMPORT_CLASSIC_MIRRORS = 'harbour/mirrors',
   LIBRARY_IMPORT_CLASSIC_TO_BBB = 'biblib/classic',

--- a/src/components/FeedbackForms/components/Checkbox.tsx
+++ b/src/components/FeedbackForms/components/Checkbox.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 export type Ref = HTMLInputElement;
+
 export interface CheckboxProps {
   onClick: (...event: any[]) => void;
 }
@@ -15,7 +16,7 @@ const Checkbox = React.forwardRef<Ref, CheckboxProps>(
         {...rest}
       />
     </label>
-  )
+  ),
 );
 
 export default Checkbox;

--- a/src/components/FeedbackForms/components/CheckboxControl.tsx
+++ b/src/components/FeedbackForms/components/CheckboxControl.tsx
@@ -15,6 +15,7 @@ export interface CheckboxControlProps {
   options: CheckboxOption[];
   inline?: boolean;
 }
+
 const CheckboxControl = React.forwardRef<Ref, CheckboxControlProps>(
   (props, ref) => {
     const { field, label, a11yPrefix, inline, helpMessage, options } = props;
@@ -30,56 +31,56 @@ const CheckboxControl = React.forwardRef<Ref, CheckboxControlProps>(
         </label>
         {inline
           ? options.map(({ label: optionLabel, key: value }) => (
-              <React.Fragment>
-                <label
-                  className="custom-checkbox"
-                  key={value}
-                  style={{ marginRight: '4px' }}
-                >
-                  <input
-                    id="{`${field}-${value}`}>{optionLabel}"
-                    type="checkbox"
-                    name={field}
-                    value={value}
-                    ref={ref}
-                  />
-                </label>
-                <label
-                  htmlFor={`${field}-${value}`}
-                  className="checkbox-inline"
-                  style={{ fontWeight: 'normal' }}
-                >
-                  {optionLabel}
-                </label>
-              </React.Fragment>
-            ))
+            <React.Fragment>
+              <label
+                className="custom-checkbox"
+                key={value}
+                style={{ marginRight: '4px' }}
+              >
+                <input
+                  id="{`${field}-${value}`}>{optionLabel}"
+                  type="checkbox"
+                  name={field}
+                  value={value}
+                  ref={ref}
+                />
+              </label>
+              <label
+                htmlFor={`${field}-${value}`}
+                className="checkbox-inline"
+                style={{ fontWeight: 'normal' }}
+              >
+                {optionLabel}
+              </label>
+            </React.Fragment>
+          ))
           : options.map(({ label: optionLabel, key: value }) => (
-              <div key={value}>
-                <label
-                  className="custom-checkbox"
-                  style={{ marginRight: '4px' }}
-                >
-                  <input
-                    type="checkbox"
-                    id="{`${field}-${value}`}>{optionLabel}"
-                    name={field}
-                    value={value}
-                    ref={ref}
-                  />
-                </label>
-                <label
-                  htmlFor={`${field}-${value}`}
-                  style={{ fontWeight: 'normal' }}
-                >
-                  {optionLabel}
-                </label>
-              </div>
-            ))}
+            <div key={value}>
+              <label
+                className="custom-checkbox"
+                style={{ marginRight: '4px' }}
+              >
+                <input
+                  type="checkbox"
+                  id="{`${field}-${value}`}>{optionLabel}"
+                  name={field}
+                  value={value}
+                  ref={ref}
+                />
+              </label>
+              <label
+                htmlFor={`${field}-${value}`}
+                style={{ fontWeight: 'normal' }}
+              >
+                {optionLabel}
+              </label>
+            </div>
+          ))}
 
         {helpMessage && <span className="help-block">{helpMessage}</span>}
       </div>
     );
-  }
+  },
 );
 
 export default CheckboxControl;

--- a/src/components/FeedbackForms/components/Control.tsx
+++ b/src/components/FeedbackForms/components/Control.tsx
@@ -5,6 +5,7 @@ interface LabelProps {
   children: React.ReactNode;
   required: boolean;
 }
+
 const Label: React.FC<LabelProps> = ({ htmlFor, children, required }) => {
   return (
     <label htmlFor={htmlFor} className="control-label">
@@ -39,6 +40,7 @@ export interface IControlProps {
   actionButtonPos?: 'start' | 'end';
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
 }
+
 const Control = React.forwardRef<Ref, IControlProps>((props, ref) => {
   const {
     type,

--- a/src/components/FeedbackForms/components/FormErrorBoundary.tsx
+++ b/src/components/FeedbackForms/components/FormErrorBoundary.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 class FormErrorBoundary extends React.Component<{ msg?: ReactNode }> {
   public state = {
-    hasError: false
+    hasError: false,
   };
 
   public static getDerivedStateFromError() {

--- a/src/components/FeedbackForms/components/FormErrorBoundary.tsx
+++ b/src/components/FeedbackForms/components/FormErrorBoundary.tsx
@@ -1,9 +1,9 @@
-import React, { ErrorInfo } from 'react';
+import React, { ErrorInfo, ReactNode } from 'react';
 import styled from 'styled-components';
 
-class FormErrorBoundary extends React.Component {
+class FormErrorBoundary extends React.Component<{ msg?: ReactNode }> {
   public state = {
-    hasError: false,
+    hasError: false
   };
 
   public static getDerivedStateFromError() {
@@ -11,11 +11,14 @@ class FormErrorBoundary extends React.Component {
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('[error]: ', error, errorInfo);
+    // console.error('[error]: ', error, errorInfo);
   }
 
   public render() {
     if (this.state.hasError) {
+      if (this.props.msg) {
+        return this.props.msg;
+      }
       return (
         <Container>
           <h4>Sorry! there was an error, please reload the page.</h4>

--- a/src/components/FeedbackForms/components/PreviewModal.tsx
+++ b/src/components/FeedbackForms/components/PreviewModal.tsx
@@ -6,6 +6,7 @@ interface IPreviewModalProps extends ModalProps {
   onSubmit: () => void;
   onCancel: () => void;
 }
+
 const PreviewModal: React.FunctionComponent<IPreviewModalProps> = ({
   onSubmit,
   onCancel,

--- a/src/components/FeedbackForms/components/RadioControl.tsx
+++ b/src/components/FeedbackForms/components/RadioControl.tsx
@@ -15,6 +15,7 @@ export interface RadioControlProps {
   options: RadioOption[];
   inline?: boolean;
 }
+
 const RadioControl = React.forwardRef<Ref, RadioControlProps>((props, ref) => {
   const { field, label, a11yPrefix, inline, helpMessage, options } = props;
   const labelId = `${a11yPrefix}_${field}_radio`;
@@ -29,19 +30,19 @@ const RadioControl = React.forwardRef<Ref, RadioControlProps>((props, ref) => {
       </label>
       {inline
         ? options.map(({ label: optionLabel, key: value }) => (
-            <label className="radio-inline custom-radio" key={value}>
+          <label className="radio-inline custom-radio" key={value}>
+            <input type="radio" name={field} value={value} ref={ref} />
+            {optionLabel}
+          </label>
+        ))
+        : options.map(({ label: optionLabel, key: value }) => (
+          <div className="radio" key={value}>
+            <label className="custom-radio">
               <input type="radio" name={field} value={value} ref={ref} />
               {optionLabel}
             </label>
-          ))
-        : options.map(({ label: optionLabel, key: value }) => (
-            <div className="radio" key={value}>
-              <label className="custom-radio">
-                <input type="radio" name={field} value={value} ref={ref} />
-                {optionLabel}
-              </label>
-            </div>
-          ))}
+          </div>
+        ))}
 
       {helpMessage && <span className="help-block">{helpMessage}</span>}
     </div>

--- a/src/components/FeedbackForms/components/SelectControl.tsx
+++ b/src/components/FeedbackForms/components/SelectControl.tsx
@@ -5,6 +5,7 @@ interface LabelProps {
   children: React.ReactNode;
   required: boolean;
 }
+
 const Label: React.FunctionComponent<LabelProps> = ({
   htmlFor,
   children,
@@ -39,6 +40,7 @@ export interface SelectControlProps {
   required?: boolean;
   children: React.ReactNode;
 }
+
 const SelectControl = React.forwardRef<Ref, SelectControlProps>(
   (props, ref) => {
     const {
@@ -85,7 +87,7 @@ const SelectControl = React.forwardRef<Ref, SelectControlProps>(
         })()}
       </div>
     );
-  }
+  },
 );
 
 export default SelectControl;

--- a/src/components/FeedbackForms/components/Tabs.tsx
+++ b/src/components/FeedbackForms/components/Tabs.tsx
@@ -13,8 +13,10 @@ const Nav = styled.nav`
 
 export interface ITabContext {
   activeTab: string;
+
   setActiveTab(label: string): void;
 }
+
 const [useCtx, TabProvider] = createCtx<ITabContext>();
 
 interface ITabsComposition {
@@ -64,6 +66,7 @@ export interface ITabProps {
   label: string;
   component: React.ReactNode;
 }
+
 const Tab: React.FC<ITabProps> = React.memo(({ label }) => {
   const { activeTab, setActiveTab } = useCtx();
 

--- a/src/components/FeedbackForms/components/createCtx.ts
+++ b/src/components/FeedbackForms/components/createCtx.ts
@@ -2,12 +2,14 @@ import React from 'react';
 
 function createCtx<A extends {} | null>() {
   const ctx = React.createContext<A | undefined>(undefined);
+
   function useCtx() {
     const c = React.useContext(ctx);
     if (c === undefined)
       throw new Error('useCtx must be inside a Provider with a value');
     return c;
   }
+
   return [useCtx, ctx.Provider] as const; // 'as const' makes TypeScript infer a tuple
 }
 

--- a/src/components/FeedbackForms/index.ts
+++ b/src/components/FeedbackForms/index.ts
@@ -1,5 +1,3 @@
-import {} from 'styled-components/cssprop';
-
 import AssociatedReferences from './AssociatedReferences';
 import MissingIncorrectRecord from './MissingIncorrectRecord';
 import SubmitCorrectAbstract from './SubmitCorrectAbstract';


### PR DESCRIPTION
Now wrap all diffing in try...catch
Try to save the user info when error occurs
Move error boundary down to preview level to keep from crashing whole
form on error
