### PR TITLE
Fix refstring sort issue

### DIFF
--- a/src/components/FeedbackForms/MissingIncorrectRecord/FormPreview.tsx
+++ b/src/components/FeedbackForms/MissingIncorrectRecord/FormPreview.tsx
@@ -182,10 +182,10 @@ const createFeedbackString = (
     _subject: 'Missing References',
     name,
     email,
-    references: bibcodes.map(({citing, cited}, i) => ({
+    references: bibcodes.map(({citing, cited}) => ({
       citing: citing.trim(),
       cited: cited.trim(),
-      refstring: referenceString[i],
+      refstring: referenceString.find(ref => ref.startsWith(cited.trim())) ?? 'not-found'
     })),
   };
 };

--- a/src/components/FeedbackForms/MissingIncorrectRecord/PreviewBody.tsx
+++ b/src/components/FeedbackForms/MissingIncorrectRecord/PreviewBody.tsx
@@ -39,6 +39,7 @@ export const fetchReference = (
       data: JSON.stringify({
         bibcode: bibcodes.map((e) => e.cited),
         format: ['%R (%1l (%Y), %Q)'],
+        sort: ['bibcode desc']
       }),
     },
   });


### PR DESCRIPTION
Explicitly set the export sort param

Re-associate the refstrings with the cited bibcodes when submitting, in case the incoming list from the export is unsorted.  If it is sorted, then this process should be fast.