### PR TITLE
fix(feedback): catch reCAPTCHA errors and show actionable failure UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
   },
   "devDependencies": {
     "@fluentui/react": "^7.106.0",
+    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/react": "^9.5.0",
     "@types/react-google-recaptcha": "^2.1.2",
     "babel-eslint": "^10.0.3",
     "cross-env": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=10"
   },
   "scripts": {
-    "build": "tsdx build --env production --format umd --name index",
+    "build": "tsdx build --env production --format umd --name index --tsconfig ./tsconfig.build.json",
     "start": "tsdx watch --name index --format umd,esm",
     "prepublish": "run-s build",
     "test": "run-s test:unit test:lint test:build",
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@fluentui/react": "^7.106.0",
     "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.5.0",
+    "@testing-library/react": "^11.0.0",
     "@types/react-google-recaptcha": "^2.1.2",
     "babel-eslint": "^10.0.3",
     "cross-env": "^7.0.2",

--- a/src/components/FeedbackForms/AssociatedReferences/FormPreview.tsx
+++ b/src/components/FeedbackForms/AssociatedReferences/FormPreview.tsx
@@ -8,7 +8,7 @@ import { AssociatedArticlesFormValues } from '../models';
 import PreviewBody from './PreviewBody';
 import { useRecaptcha } from '../../../hooks/useRecaptcha';
 
-const fetchBibcodes = ([bibcodes]: [string[]]) => {
+const fetchBibcodes = ([bibcodes]: string[][]) => {
   return apiFetch({
     target: ApiTarget.SEARCH,
     query: {

--- a/src/components/FeedbackForms/MissingIncorrectRecord/FormPreview.tsx
+++ b/src/components/FeedbackForms/MissingIncorrectRecord/FormPreview.tsx
@@ -9,7 +9,7 @@ import {defaultValues} from './MissingIncorrectRecord';
 import PreviewBody, {fetchReference} from './PreviewBody';
 import {useRecaptcha} from '../../../hooks/useRecaptcha';
 
-const fetchBibcodes = ([bibcodes]: [string[]]) => {
+const fetchBibcodes = ([bibcodes]: string[][]) => {
   return apiFetch({
     target: ApiTarget.SEARCH,
     query: {

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/DiffView.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/DiffView.tsx
@@ -76,7 +76,7 @@ const TextChanges = ({ keyProp, changes, right }: ITextChangeElementProps) => {
   return (
     <>
       <Bold>Diff:</Bold>
-      {changes.reduce((list, change) => {
+      {changes.reduce((list: React.ReactElement[], change) => {
         if (change.added) {
           return [...list, <Add inline>{change.value}</Add>];
         } else if (change.removed) {
@@ -101,7 +101,7 @@ const ArrayChanges = ({ keyProp, changes }: IArrayChangeElementProps) => {
   let i = 0;
   return (
     <>
-      {changes.reduce((val, change) => {
+      {changes.reduce((val: React.ReactElement[], change) => {
         if (change.added) {
           const currentCount = i;
           i += change.count || 0;
@@ -234,7 +234,7 @@ const strikeText = (str: string) => {
 
 const stringifyArrayChanges = (changes: ArrayChange<string>[]) => {
   // spread out entries
-  const entries = changes.reduce((acc, change) => {
+  const entries = changes.reduce((acc: Change[], change) => {
     return [
       ...acc,
       ...change.value.map((v) => ({ count: 1, ...change, value: v })),
@@ -248,7 +248,8 @@ const stringifyArrayChanges = (changes: ArrayChange<string>[]) => {
     if (
       count > 1 &&
       entries[i].removed &&
-      entries[i + count].count > 1 &&
+      entries[i + count] &&
+      (entries[i + count].count ?? 0) > 1 &&
       entries[i + count].added
     ) {
       // actual change made to multiple entries in a row, they are matched by index, not sequential
@@ -278,7 +279,7 @@ const stringifyArrayChanges = (changes: ArrayChange<string>[]) => {
       out.push(`+ ${index} ${entries[i].value}`);
       index += 1;
     } else if (
-      entries[i].count > 1 &&
+      (entries[i].count ?? 0) > 1 &&
       !entries[i].added &&
       !entries[i].removed
     ) {

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/FormPreview.test.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/FormPreview.test.tsx
@@ -1,0 +1,83 @@
+// MutationObserver is used by react-hook-form but is absent from the jsdom version
+// shipped with react-scripts 3.x. Provide a minimal stub to prevent crashes.
+if (typeof MutationObserver === 'undefined') {
+  (global as any).MutationObserver = class {
+    observe() {}
+    disconnect() {}
+    takeRecords() { return []; }
+  };
+}
+
+import React from 'react';
+import { render, screen, fireEvent, act, wait } from '@testing-library/react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { SubmitCorrectAbstractFormValues } from '../models';
+import FormPreview from './FormPreview';
+import { FormSubmissionCtx, OriginCtx, defaultValues } from './SubmitCorrectAbstract';
+
+// Mock the recaptcha hook to simulate reCAPTCHA not being loaded
+jest.mock('../../../hooks/useRecaptcha', () => ({
+  useRecaptcha: () => ({
+    execute: () => Promise.reject('Recaptcha not loaded'),
+  }),
+}));
+
+// Mock apiFetch so no real network calls happen
+jest.mock('../api', () => ({
+  apiFetch: jest.fn(),
+  ApiTarget: { FEEDBACK: 'feedback', FEEDBACK_FALLBACK: 'feedback_fallback', SEARCH: 'search' },
+}));
+
+// Mock the SubmitCorrectAbstract internal API module (uses lodash global _ which is unavailable in jsdom)
+jest.mock('./api', () => ({
+  fetchFullRecord: jest.fn(),
+}));
+
+const Wrapper: React.FC = ({ children }) => {
+  const methods = useForm<SubmitCorrectAbstractFormValues>({ defaultValues });
+  const [submissionState, setSubmissionState] = React.useState<any>(null);
+  const submissionValue = { submissionState, setSubmissionState };
+  const originValue = { origin: defaultValues, setOrigin: () => null };
+
+  return (
+    <FormProvider {...(methods as any)}>
+      <FormSubmissionCtx.Provider value={submissionValue}>
+        <OriginCtx.Provider value={originValue}>
+          {children}
+          <div data-testid="submission-state">
+            {submissionState ? JSON.stringify(submissionState) : 'null'}
+          </div>
+        </OriginCtx.Provider>
+      </FormSubmissionCtx.Provider>
+    </FormProvider>
+  );
+};
+
+it('sets error state when recaptcha is not loaded', async () => {
+  render(
+    <Wrapper>
+      <FormPreview />
+    </Wrapper>
+  );
+
+  // Click Preview to open the modal
+  await act(async () => {
+    fireEvent.click(screen.getByText('Preview'));
+  });
+
+  // Click Submit inside the modal — triggers handleSubmit which calls execute()
+  await act(async () => {
+    fireEvent.click(screen.getByText('Submit'));
+  });
+
+  // Wait for the async rejection to propagate and state to update
+  await wait(() => {
+    const stateEl = screen.getByTestId('submission-state');
+    expect(stateEl.textContent).not.toBe('null');
+  });
+
+  const stateEl = screen.getByTestId('submission-state');
+  const state = JSON.parse(stateEl.textContent!);
+  expect(state.status).toBe('error');
+  expect(state.message).toContain('Recaptcha');
+});

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/FormPreview.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/FormPreview.tsx
@@ -69,34 +69,32 @@ const FormPreview: React.FunctionComponent<IFormPreview> = ({
   const {setSubmissionState} = React.useContext(FormSubmissionCtx);
 
   const handleSubmit = async () => {
-    setSubmissionState({status: 'pending'});
-
+    setSubmissionState({ status: 'pending' });
 
     if (previewRef.current) {
       const currentValues = {
         ...origin,
         ...getValues(),
-        recaptcha: await execute(),
       };
 
       try {
+        const recaptchaToken = await execute();
         await submitFeedback(
           createFeedbackString(
             origin,
-            currentValues,
+            { ...currentValues, recaptcha: recaptchaToken },
             getSafeDiff(origin, currentValues),
           ),
         );
         if (typeof onSubmit === 'function') {
           onSubmit();
         }
-
-        setSubmissionState({status: 'success'});
+        setSubmissionState({ status: 'success' });
         handleReset();
       } catch (e) {
         setSubmissionState({
           status: 'error',
-          message: e?.responseJSON?.message,
+          message: typeof e === 'string' ? e : e instanceof Error ? e.message : e?.responseJSON?.message ?? 'An error occurred',
           code: e?.status,
           changes: getSafeDiff(origin, currentValues),
         });

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/FormStatus.test.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/FormStatus.test.tsx
@@ -43,7 +43,7 @@ it('shows user-friendly message when recaptcha fails', () => {
       }}
     />
   );
-  expect(screen.getByText(/security check/i)).toBeTruthy();
+  expect(screen.getByText(/security check could not load/i)).toBeTruthy();
 });
 
 it('shows copyable changes block when diff is available', () => {

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/FormStatus.test.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/FormStatus.test.tsx
@@ -46,7 +46,7 @@ it('shows user-friendly message when recaptcha fails', () => {
   expect(screen.getByText(/security check could not load/i)).toBeTruthy();
 });
 
-it('shows copyable changes block when diff is available', () => {
+it('shows copy button when diff is available', () => {
   render(
     <Wrapper
       submissionState={{
@@ -56,7 +56,9 @@ it('shows copyable changes block when diff is available', () => {
       }}
     />
   );
-  expect(screen.getByText('title: Old Title -> New Title')).toBeTruthy();
+  expect(
+    screen.getByText(/copy your changes to include in an email/i)
+  ).toBeTruthy();
 });
 
 it('shows generic server error for 500', () => {

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/FormStatus.test.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/FormStatus.test.tsx
@@ -1,0 +1,88 @@
+// MutationObserver is used by react-hook-form but is absent from the jsdom version
+// shipped with react-scripts 3.x. Provide a minimal stub to prevent crashes.
+if (typeof MutationObserver === 'undefined') {
+  (global as any).MutationObserver = class {
+    observe() {}
+    disconnect() {}
+    takeRecords() { return []; }
+  };
+}
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { SubmitCorrectAbstractFormValues } from '../models';
+import FormStatus from './FormStatus';
+import { FormSubmissionCtx } from './SubmitCorrectAbstract';
+
+// Mock the SubmitCorrectAbstract internal API module (uses lodash global _ which is unavailable in jsdom)
+jest.mock('./api', () => ({
+  fetchFullRecord: jest.fn(),
+}));
+
+const Wrapper: React.FC<{ submissionState: any }> = ({ submissionState }) => {
+  const methods = useForm<SubmitCorrectAbstractFormValues>();
+  return (
+    <FormProvider {...(methods as any)}>
+      <FormSubmissionCtx.Provider
+        value={{ submissionState, setSubmissionState: () => null }}
+      >
+        <FormStatus />
+      </FormSubmissionCtx.Provider>
+    </FormProvider>
+  );
+};
+
+it('shows user-friendly message when recaptcha fails', () => {
+  render(
+    <Wrapper
+      submissionState={{
+        status: 'error',
+        message: 'Recaptcha not loaded',
+        changes: encodeURIComponent('title: Old Title -> New Title'),
+      }}
+    />
+  );
+  expect(screen.getByText(/security check/i)).toBeTruthy();
+});
+
+it('shows copyable changes block when diff is available', () => {
+  render(
+    <Wrapper
+      submissionState={{
+        status: 'error',
+        message: 'Recaptcha not loaded',
+        changes: encodeURIComponent('title: Old Title -> New Title'),
+      }}
+    />
+  );
+  expect(screen.getByText('title: Old Title -> New Title')).toBeTruthy();
+});
+
+it('shows generic server error for 500', () => {
+  render(
+    <Wrapper
+      submissionState={{
+        status: 'error',
+        message: 'Internal Server Error',
+        code: 500,
+        changes: '',
+      }}
+    />
+  );
+  expect(screen.getByText(/error processing/i)).toBeTruthy();
+});
+
+it('does not show copyable block when changes is empty', () => {
+  render(
+    <Wrapper
+      submissionState={{
+        status: 'error',
+        message: 'Something failed',
+        code: 500,
+        changes: '',
+      }}
+    />
+  );
+  expect(screen.queryByText(/copy your changes/i)).toBeNull();
+});

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/FormStatus.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/FormStatus.tsx
@@ -6,6 +6,8 @@ import { SubmitCorrectAbstractFormValues } from '../models';
 import { FormSubmissionCtx } from './SubmitCorrectAbstract';
 
 const CopyableChanges: React.FunctionComponent<{ changes: string }> = ({ changes }) => {
+  const [copied, setCopied] = React.useState(false);
+
   if (!changes || changes === 'Unable%20to%20generate%20diff') {
     return null;
   }
@@ -21,27 +23,27 @@ const CopyableChanges: React.FunctionComponent<{ changes: string }> = ({ changes
     return null;
   }
 
+  const handleCopy = () => {
+    navigator.clipboard.writeText(decoded).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
   return (
-    <details style={{ marginTop: '0.75rem' }}>
-      <summary style={{ cursor: 'pointer' }}>
-        Copy your changes to include in an email
-      </summary>
-      <pre
-        style={{
-          marginTop: '0.5rem',
-          padding: '0.75rem',
-          background: '#f5f5f5',
-          border: '1px solid #ddd',
-          borderRadius: '3px',
-          fontSize: '12px',
-          whiteSpace: 'pre-wrap',
-          wordBreak: 'break-word',
-          userSelect: 'all',
-        }}
+    <div style={{ marginTop: '0.75rem' }}>
+      <button
+        type="button"
+        className="btn btn-default"
+        onClick={handleCopy}
       >
-        {decoded}
-      </pre>
-    </details>
+        <i
+          className={`fa ${copied ? 'fa-check' : 'fa-clipboard'}`}
+          aria-hidden
+        />{' '}
+        {copied ? 'Copied!' : 'Copy your changes to include in an email'}
+      </button>
+    </div>
   );
 };
 
@@ -62,12 +64,12 @@ const FormStatus: React.FunctionComponent = () => {
   }
 
   if (submissionState?.status === 'pending') {
-    return <AlertModal type={AlertType.LOADING}>Submitting...</AlertModal>;
+    return <AlertModal key="pending" type={AlertType.LOADING}>Submitting...</AlertModal>;
   }
 
   if (submissionState?.status === 'success') {
     return (
-      <AlertModal type={AlertType.SUCCESS}>Submitted, thank you!</AlertModal>
+      <AlertModal key="success" type={AlertType.SUCCESS}>Submitted, thank you!</AlertModal>
     );
   }
 
@@ -86,6 +88,7 @@ const FormStatus: React.FunctionComponent = () => {
     if (isRecaptchaError) {
       return (
         <AlertModal
+          key="error-recaptcha"
           type={AlertType.ERROR}
           title="Security Check Failed"
           timeout={0}
@@ -105,7 +108,7 @@ const FormStatus: React.FunctionComponent = () => {
 
     if (hasHttpError) {
       return (
-        <AlertModal type={AlertType.ERROR} timeout={0}>
+        <AlertModal key="error-http" type={AlertType.ERROR} timeout={0}>
           <p>
             There was an error processing the request, please try again, or
             send an email with your changes to{' '}
@@ -117,7 +120,7 @@ const FormStatus: React.FunctionComponent = () => {
     }
 
     return (
-      <AlertModal type={AlertType.ERROR} timeout={0}>
+      <AlertModal key="error-generic" type={AlertType.ERROR} timeout={0}>
         <p>{submissionState.message}</p>
         <p>
           Please try again, or send an email with your changes to{' '}

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/FormStatus.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/FormStatus.tsx
@@ -85,40 +85,46 @@ const FormStatus: React.FunctionComponent = () => {
 
     if (isRecaptchaError) {
       return (
-        <div className="alert alert-warning" style={{ marginTop: '1rem' }}>
+        <AlertModal
+          type={AlertType.ERROR}
+          title="Security Check Failed"
+          timeout={0}
+        >
           <p>
-            Our security check could not load. Please refresh the page and try
-            again.
+            Our security check could not load. Please refresh the page and
+            try again.
           </p>
           <p>
             If the problem persists, send an email with your changes to{' '}
             <strong>adshelp@cfa.harvard.edu</strong>.
           </p>
           <CopyableChanges changes={submissionState.changes} />
-        </div>
+        </AlertModal>
       );
     }
 
     if (hasHttpError) {
       return (
-        <div className="alert alert-warning" style={{ marginTop: '1rem' }}>
-          There was an error processing the request, please try again, or send
-          an email with your changes to{' '}
-          <strong>adshelp@cfa.harvard.edu</strong>.
+        <AlertModal type={AlertType.ERROR} timeout={0}>
+          <p>
+            There was an error processing the request, please try again, or
+            send an email with your changes to{' '}
+            <strong>adshelp@cfa.harvard.edu</strong>.
+          </p>
           <CopyableChanges changes={submissionState.changes} />
-        </div>
+        </AlertModal>
       );
     }
 
     return (
-      <div className="alert alert-warning" style={{ marginTop: '1rem' }}>
+      <AlertModal type={AlertType.ERROR} timeout={0}>
         <p>{submissionState.message}</p>
         <p>
           Please try again, or send an email with your changes to{' '}
           <strong>adshelp@cfa.harvard.edu</strong>.
         </p>
         <CopyableChanges changes={submissionState.changes} />
-      </div>
+      </AlertModal>
     );
   }
 

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/SubmitCorrectAbstract.test.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/SubmitCorrectAbstract.test.tsx
@@ -1,0 +1,22 @@
+import { SubmissionState } from './SubmitCorrectAbstract';
+
+// TypeScript compile-time test: SubmissionState error must allow missing code
+const stateWithCode: SubmissionState = {
+  status: 'error',
+  message: 'Something failed',
+  code: 500,
+  changes: 'some diff',
+};
+
+const stateWithoutCode: SubmissionState = {
+  status: 'error',
+  message: 'Recaptcha not loaded',
+  changes: 'some diff',
+  // code intentionally omitted
+};
+
+it('SubmissionState allows error without code', () => {
+  expect(stateWithoutCode.status).toBe('error');
+  expect(stateWithCode.code).toBe(500);
+  expect(stateWithoutCode.code).toBeUndefined();
+});

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/SubmitCorrectAbstract.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/SubmitCorrectAbstract.tsx
@@ -99,7 +99,7 @@ export const OriginCtx = React.createContext<IOriginContext>({
 
 export type SubmissionState =
   | { status: 'pending' }
-  | { status: 'error'; message: string; code: number; changes: string }
+  | { status: 'error'; message: string; code?: number; changes: string }
   | { status: 'success' }
   | null;
 

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/api/index.ts
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/api/index.ts
@@ -1,1 +1,2 @@
-export { default as fetchFullRecord, FullRecord } from './fetchFullRecord';
+export { default as fetchFullRecord } from './fetchFullRecord';
+export type { FullRecord } from './fetchFullRecord';

--- a/src/components/FeedbackForms/components/AlertModal.tsx
+++ b/src/components/FeedbackForms/components/AlertModal.tsx
@@ -28,7 +28,7 @@ const AlertModal: React.FC<IAlertModalProps> = (props) => {
 
   React.useEffect(() => {
     let id: number;
-    if (open) {
+    if (open && timeout > 0) {
       id = setTimeout(close, timeout);
     }
     return () => clearTimeout(id);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,8 +1,8 @@
 export {
   default as useBumblebee,
   PubSubEvent,
-  JSONResponse,
 } from './useBumblebee';
+export type { JSONResponse } from './useBumblebee';
 
 export { default as useAsync } from './useAsync';
 

--- a/src/hooks/useRecaptcha.ts
+++ b/src/hooks/useRecaptcha.ts
@@ -1,37 +1,98 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useRef} from 'react';
 import {useBumblebee} from './index';
 
 declare global {
   export interface Window {
     grecaptcha: {
       ready: (cb: () => void) => void;
-      execute: (siteKey: string, options: { action: string }) => Promise<string>;
-    }
+      execute: (
+        siteKey: string,
+        options: { action: string }
+      ) => Promise<string>;
+    };
   }
 }
+
+const SCRIPT_ID = 'ads-recaptcha-script';
+
+const loadScript = (siteKey: string): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const existing = document.getElementById(SCRIPT_ID);
+    if (existing && existing.parentNode) {
+      existing.parentNode.removeChild(existing);
+    }
+
+    const script = document.createElement('script');
+    script.id = SCRIPT_ID;
+    script.async = true;
+    script.defer = true;
+    script.src =
+      'https://www.google.com/recaptcha/api.js?render=' +
+      encodeURIComponent(siteKey);
+
+    script.onload = () => {
+      if (
+        window.grecaptcha &&
+        typeof window.grecaptcha.ready === 'function'
+      ) {
+        window.grecaptcha.ready(() => resolve());
+      } else {
+        reject(new Error('reCAPTCHA did not initialize'));
+      }
+    };
+
+    script.onerror = () => {
+      reject(new Error('reCAPTCHA failed to load'));
+    };
+
+    document.head.appendChild(script);
+  });
+};
+
 export const useRecaptcha = (formName: string) => {
   const {getAppConfig} = useBumblebee();
-  const siteKey = React.useMemo(() => getAppConfig().recaptchaKey, [
-    getAppConfig,
-  ]);
+  const siteKey = React.useMemo(
+    () => getAppConfig().recaptchaKey,
+    [getAppConfig],
+  );
+  const loadPromiseRef = useRef<Promise<void> | null>(null);
+
+  React.useEffect(() => {
+    if (window.grecaptcha) {
+      return;
+    }
+    if (!siteKey) {
+      return;
+    }
+    loadPromiseRef.current = loadScript(siteKey);
+  }, [siteKey]);
 
   const execute = useCallback(() => {
     return new Promise<string>((resolve, reject) => {
-      if (window.grecaptcha) {
+      const run = () => {
+        if (!window.grecaptcha) {
+          reject(new Error('reCAPTCHA not loaded'));
+          return;
+        }
         window.grecaptcha.ready(() => {
-          window.grecaptcha.execute(siteKey, {action: `feedback/${formName}`}).then((token) => {
-            resolve(token);
-          }).catch((err) => {
-            reject(err);
-          })
+          window.grecaptcha
+            .execute(siteKey, {action: `feedback/${formName}`})
+            .then(resolve)
+            .catch(reject);
         });
+      };
+
+      if (window.grecaptcha) {
+        run();
+      } else if (loadPromiseRef.current) {
+        loadPromiseRef.current.then(run).catch(reject);
       } else {
-        reject('Recaptcha not loaded');
+        reject(new Error('reCAPTCHA not loaded'));
       }
     });
-  }, [window.grecaptcha, siteKey, formName]);
+  }, [siteKey, formName]);
 
   return {
     execute,
   };
-}
+};

--- a/src/hooks/useRecaptcha.ts
+++ b/src/hooks/useRecaptcha.ts
@@ -64,10 +64,16 @@ export const useRecaptcha = (formName: string) => {
     if (!siteKey) {
       return;
     }
-    loadPromiseRef.current = loadScript(siteKey);
+    loadPromiseRef.current = loadScript(siteKey).catch(() => {
+      // Suppress unhandled rejection here; execute() surfaces the error
+    });
   }, [siteKey]);
 
   const execute = useCallback(() => {
+    if (!siteKey) {
+      return Promise.resolve('dev-bypass');
+    }
+
     return new Promise<string>((resolve, reject) => {
       const run = () => {
         if (!window.grecaptcha) {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "dist",
+    "example",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/setupTests.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,10 @@
   "compilerOptions": {
     "outDir": "dist",
     "module": "esnext",
-    "lib": ["dom", "esnext"],
+    "lib": [
+      "dom",
+      "esnext"
+    ],
     "moduleResolution": "node",
     "jsx": "react",
     "sourceMap": true,
@@ -16,8 +19,21 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "target": "es5",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "noEmit": true
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist", "example"]
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "example"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,6 +17,15 @@
   dependencies:
     "@babel/highlight" "^7.8.3"
 
+"@babel/code-frame@^7.10.4":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.0.tgz#7cd7a59f15b3cc0dcd803038f7792712a7d0b15c"
+  integrity sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.28.5"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
 "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.0":
   version "7.26.2"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz"
@@ -277,6 +286,11 @@
   version "7.25.9"
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz"
   integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
+
+"@babel/helper-validator-identifier@^7.28.5":
+  version "7.28.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz#010b6938fab7cb7df74aa2bbc06aa503b8fe5fb4"
+  integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
 
 "@babel/helper-validator-option@^7.25.9":
   version "7.25.9"
@@ -1050,6 +1064,13 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-transform-typescript" "^7.9.0"
 
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz#56cd28ec515364482afeb880b476936a702461b9"
+  integrity sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==
+  dependencies:
+    core-js-pure "^3.48.0"
+
 "@babel/runtime-corejs3@^7.8.3":
   version "7.9.2"
   resolved "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz"
@@ -1071,6 +1092,11 @@
   integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
   dependencies:
     regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.5.1":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
+  integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
 
 "@babel/runtime@^7.4.2", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3":
   version "7.9.6"
@@ -1395,6 +1421,16 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@jest/types@^25.5.0":
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
+  integrity sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^15.0.0"
+    chalk "^3.0.0"
+
 "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.5"
   resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz"
@@ -1516,6 +1552,11 @@
   resolved "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.0.5.tgz"
   integrity sha512-9WKaGVpQH905Aqkk+BczFEeLQxS07rl04afFRPUG9IcSlOwmo5EVVuuNu0d4M9LMYucObvK0LoAe+5HfMW2QhQ==
 
+"@sheerun/mutationobserver-shim@^0.3.2":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#5405ee8e444ed212db44e79351f0c70a582aae25"
+  integrity sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==
+
 "@svgr/babel-plugin-add-jsx-attribute@^4.2.0":
   version "4.2.0"
   resolved "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz"
@@ -1618,6 +1659,62 @@
     "@svgr/plugin-jsx" "^4.3.3"
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
+
+"@testing-library/dom@*":
+  version "10.4.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.1.tgz#d444f8a889e9a46e9a3b4f3b88e0fcb3efb6cf95"
+  integrity sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "5.3.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.5.0"
+    picocolors "1.1.1"
+    pretty-format "^27.0.2"
+
+"@testing-library/dom@^6.15.0":
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.16.0.tgz#04ada27ed74ad4c0f0d984a1245bb29b1fd90ba9"
+  integrity sha512-lBD88ssxqEfz0wFL6MeUyyWZfV/2cjEZZV3YRpb2IoJRej/4f1jB0TzqIOznTpfR1r34CNesrubxwIlAQ8zgPA==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    "@types/testing-library__dom" "^6.12.1"
+    aria-query "^4.0.2"
+    dom-accessibility-api "^0.3.0"
+    pretty-format "^25.1.0"
+    wait-for-expect "^3.0.2"
+
+"@testing-library/jest-dom@^4.2.4":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-4.2.4.tgz#00dfa0cbdd837d9a3c2a7f3f0a248ea6e7b89742"
+  integrity sha512-j31Bn0rQo12fhCWOUWy9fl7wtqkp7In/YP2p5ZFyRuiiB9Qs3g+hS4gAmDWONbAHcRmVooNJ5eOHQDCOmUFXHg==
+  dependencies:
+    "@babel/runtime" "^7.5.1"
+    chalk "^2.4.1"
+    css "^2.2.3"
+    css.escape "^1.5.1"
+    jest-diff "^24.0.0"
+    jest-matcher-utils "^24.0.0"
+    lodash "^4.17.11"
+    pretty-format "^24.0.0"
+    redent "^3.0.0"
+
+"@testing-library/react@^9.5.0":
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-9.5.0.tgz#71531655a7890b61e77a1b39452fbedf0472ca5e"
+  integrity sha512-di1b+D0p+rfeboHO5W7gTVeZDIK5+maEgstrZbWZSSvxDyfDRkkyBE1AJR5Psd6doNldluXlCWqXriUfqu/9Qg==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@testing-library/dom" "^6.15.0"
+    "@types/testing-library__react" "^9.1.2"
+
+"@types/aria-query@^5.0.1":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
+  integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
 
 "@types/babel__core@^7.1.0":
   version "7.1.7"
@@ -1756,6 +1853,11 @@
   resolved "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
 
+"@types/react-dom@*":
+  version "19.2.3"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-19.2.3.tgz#c1e305d15a52a3e508d54dca770d202cb63abf2c"
+  integrity sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==
+
 "@types/react-google-recaptcha@^2.1.2":
   version "2.1.2"
   resolved "https://registry.npmjs.org/@types/react-google-recaptcha/-/react-google-recaptcha-2.1.2.tgz"
@@ -1832,6 +1934,29 @@
     "@types/react-native" "*"
     csstype "^2.2.0"
 
+"@types/testing-library__dom@*":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-7.5.0.tgz#e0a00dd766983b1d6e9d10d33e708005ce6ad13e"
+  integrity sha512-mj1aH4cj3XUpMEgVpognma5kHVtbm6U6cHZmEFzCRiXPvKkuHrFr3+yXdGLXvfFRBaQIVshPGHI+hGTOJlhS/g==
+  dependencies:
+    "@testing-library/dom" "*"
+
+"@types/testing-library__dom@^6.12.1":
+  version "6.14.0"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-6.14.0.tgz#1aede831cb4ed4a398448df5a2c54b54a365644e"
+  integrity sha512-sMl7OSv0AvMOqn1UJ6j1unPMIHRXen0Ita1ujnMX912rrOcawe4f7wu0Zt9GIQhBhJvH2BaibqFgQ3lP+Pj2hA==
+  dependencies:
+    pretty-format "^24.3.0"
+
+"@types/testing-library__react@^9.1.2":
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react/-/testing-library__react-9.1.3.tgz#35eca61cc6ea923543796f16034882a1603d7302"
+  integrity sha512-iCdNPKU3IsYwRK9JieSYAiX0+aYDXOGAmrC/3/M7AqqSDKnWWVv07X+Zk1uFSL7cMTUYzv4lQRfohucEocn5/w==
+  dependencies:
+    "@types/react-dom" "*"
+    "@types/testing-library__dom" "*"
+    pretty-format "^25.1.0"
+
 "@types/underscore@^1.10.11":
   version "1.10.11"
   resolved "https://registry.npmjs.org/@types/underscore/-/underscore-1.10.11.tgz"
@@ -1851,6 +1976,13 @@
   version "13.0.8"
   resolved "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz"
   integrity sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^15.0.0":
+  version "15.0.20"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.20.tgz#6d00a124c9f757427d4ca3cbc87daea778053c68"
+  integrity sha512-KIkX+/GgfFitlASYCGoSF+T4XRXhOubJLhkLVtSfsRTe9jWMmuM2g28zQ41BtPTG7TRBb2xHW+LCNVE9QR/vsg==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -2267,6 +2399,11 @@ ansi-regex@^5.0.0:
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
@@ -2279,6 +2416,13 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
+
 ansi-styles@^4.1.0:
   version "4.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz"
@@ -2286,6 +2430,11 @@ ansi-styles@^4.1.0:
   dependencies:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -2315,6 +2464,13 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-query@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
+  integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
+  dependencies:
+    dequal "^2.0.3"
+
 aria-query@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz"
@@ -2322,6 +2478,14 @@ aria-query@^3.0.0:
   dependencies:
     ast-types-flow "0.0.7"
     commander "^2.11.0"
+
+aria-query@^4.0.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
 
 arity-n@^1.0.4:
   version "1.0.4"
@@ -3657,6 +3821,11 @@ core-js-pure@^3.0.0:
   resolved "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz"
   integrity sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==
 
+core-js-pure@^3.48.0:
+  version "3.48.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.48.0.tgz#7d5a3fe1ec3631b9aa76a81c843ac2ce918e5023"
+  integrity sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==
+
 core-js@^2.4.0, core-js@^2.6.5:
   version "2.6.11"
   resolved "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz"
@@ -3905,7 +4074,12 @@ css-what@^3.2.1:
   resolved "https://registry.npmjs.org/css-what/-/css-what-3.2.1.tgz"
   integrity sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw==
 
-css@^2.0.0:
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==
+
+css@^2.0.0, css@^2.2.3:
   version "2.2.4"
   resolved "https://registry.npmjs.org/css/-/css-2.2.4.tgz"
   integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
@@ -4193,6 +4367,11 @@ depd@~1.1.2:
   resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+dequal@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
 des.js@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz"
@@ -4292,6 +4471,16 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz#511e5993dd673b97c87ea47dba0e3892f7e0c983"
+  integrity sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -6685,7 +6874,7 @@ jest-config@^24.9.0:
     pretty-format "^24.9.0"
     realpath-native "^1.1.0"
 
-jest-diff@^24.3.0, jest-diff@^24.9.0:
+jest-diff@^24.0.0, jest-diff@^24.3.0, jest-diff@^24.9.0:
   version "24.9.0"
   resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz"
   integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
@@ -6802,7 +6991,7 @@ jest-leak-detector@^24.9.0:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
 
-jest-matcher-utils@^24.9.0:
+jest-matcher-utils@^24.0.0, jest-matcher-utils@^24.9.0:
   version "24.9.0"
   resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz"
   integrity sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
@@ -7479,6 +7668,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
+
 magic-string@^0.25.2, magic-string@^0.25.5:
   version "0.25.7"
   resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz"
@@ -7696,6 +7890,11 @@ mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 mini-css-extract-plugin@0.9.0:
   version "0.9.0"
@@ -8600,7 +8799,7 @@ performance-now@^2.1.0:
   resolved "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picocolors@^1.0.0, picocolors@^1.1.0:
+picocolors@1.1.1, picocolors@^1.0.0, picocolors@^1.1.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -9406,7 +9605,7 @@ pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
-pretty-format@^24.9.0:
+pretty-format@^24.0.0, pretty-format@^24.3.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -9415,6 +9614,25 @@ pretty-format@^24.9.0:
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
+
+pretty-format@^25.1.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
+  integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
 
 private@^0.1.8:
   version "0.1.8"
@@ -9752,10 +9970,15 @@ react-hook-form@^6.5.3:
   resolved "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.5.3.tgz"
   integrity sha512-ID0z1udMQueWta3cceQUBaWLqZZLwSNWkxXYcuxa0nbII+mnggmGiEQW7PuWBBkEXv6GdHlu4PNqRj/FoeDpRg==
 
-react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
+react-is@^16.12.0, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -9980,6 +10203,14 @@ recursive-readdir@2.2.2:
   integrity sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==
   dependencies:
     minimatch "3.0.4"
+
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
 
 redux@^4.0.0:
   version "4.0.5"
@@ -11189,6 +11420,13 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
+
 strip-json-comments@^3.0.1:
   version "3.1.0"
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz"
@@ -11985,6 +12223,11 @@ w3c-xmlserializer@^1.1.2:
     domexception "^1.0.1"
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
+
+wait-for-expect@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
+  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1421,15 +1421,16 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jest/types@^25.5.0":
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
-  integrity sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
+"@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
     "@types/yargs" "^15.0.0"
-    chalk "^3.0.0"
+    chalk "^4.0.0"
 
 "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.5"
@@ -1552,11 +1553,6 @@
   resolved "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.0.5.tgz"
   integrity sha512-9WKaGVpQH905Aqkk+BczFEeLQxS07rl04afFRPUG9IcSlOwmo5EVVuuNu0d4M9LMYucObvK0LoAe+5HfMW2QhQ==
 
-"@sheerun/mutationobserver-shim@^0.3.2":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#5405ee8e444ed212db44e79351f0c70a582aae25"
-  integrity sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==
-
 "@svgr/babel-plugin-add-jsx-attribute@^4.2.0":
   version "4.2.0"
   resolved "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz"
@@ -1660,32 +1656,19 @@
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
 
-"@testing-library/dom@*":
-  version "10.4.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.1.tgz#d444f8a889e9a46e9a3b4f3b88e0fcb3efb6cf95"
-  integrity sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==
+"@testing-library/dom@^7.28.1":
+  version "7.31.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.31.2.tgz#df361db38f5212b88555068ab8119f5d841a8c4a"
+  integrity sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
-    "@types/aria-query" "^5.0.1"
-    aria-query "5.3.0"
-    dom-accessibility-api "^0.5.9"
-    lz-string "^1.5.0"
-    picocolors "1.1.1"
-    pretty-format "^27.0.2"
-
-"@testing-library/dom@^6.15.0":
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.16.0.tgz#04ada27ed74ad4c0f0d984a1245bb29b1fd90ba9"
-  integrity sha512-lBD88ssxqEfz0wFL6MeUyyWZfV/2cjEZZV3YRpb2IoJRej/4f1jB0TzqIOznTpfR1r34CNesrubxwIlAQ8zgPA==
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@sheerun/mutationobserver-shim" "^0.3.2"
-    "@types/testing-library__dom" "^6.12.1"
-    aria-query "^4.0.2"
-    dom-accessibility-api "^0.3.0"
-    pretty-format "^25.1.0"
-    wait-for-expect "^3.0.2"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.6"
+    lz-string "^1.4.4"
+    pretty-format "^26.6.2"
 
 "@testing-library/jest-dom@^4.2.4":
   version "4.2.4"
@@ -1702,19 +1685,18 @@
     pretty-format "^24.0.0"
     redent "^3.0.0"
 
-"@testing-library/react@^9.5.0":
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-9.5.0.tgz#71531655a7890b61e77a1b39452fbedf0472ca5e"
-  integrity sha512-di1b+D0p+rfeboHO5W7gTVeZDIK5+maEgstrZbWZSSvxDyfDRkkyBE1AJR5Psd6doNldluXlCWqXriUfqu/9Qg==
+"@testing-library/react@^11.0.0":
+  version "11.2.7"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.7.tgz#b29e2e95c6765c815786c0bc1d5aed9cb2bf7818"
+  integrity sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==
   dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@testing-library/dom" "^6.15.0"
-    "@types/testing-library__react" "^9.1.2"
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^7.28.1"
 
-"@types/aria-query@^5.0.1":
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
-  integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
+"@types/aria-query@^4.2.0":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
+  integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
 "@types/babel__core@^7.1.0":
   version "7.1.7"
@@ -1816,6 +1798,13 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz#0f03e3d2f670fbdac586e34b433783070cc16f54"
+  integrity sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==
+  dependencies:
+    "@types/istanbul-lib-report" "*"
+
 "@types/jest@^24.0.15":
   version "24.9.1"
   resolved "https://registry.npmjs.org/@types/jest/-/jest-24.9.1.tgz"
@@ -1852,11 +1841,6 @@
   version "1.5.2"
   resolved "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
-
-"@types/react-dom@*":
-  version "19.2.3"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-19.2.3.tgz#c1e305d15a52a3e508d54dca770d202cb63abf2c"
-  integrity sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==
 
 "@types/react-google-recaptcha@^2.1.2":
   version "2.1.2"
@@ -1933,29 +1917,6 @@
     "@types/react" "*"
     "@types/react-native" "*"
     csstype "^2.2.0"
-
-"@types/testing-library__dom@*":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-7.5.0.tgz#e0a00dd766983b1d6e9d10d33e708005ce6ad13e"
-  integrity sha512-mj1aH4cj3XUpMEgVpognma5kHVtbm6U6cHZmEFzCRiXPvKkuHrFr3+yXdGLXvfFRBaQIVshPGHI+hGTOJlhS/g==
-  dependencies:
-    "@testing-library/dom" "*"
-
-"@types/testing-library__dom@^6.12.1":
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-6.14.0.tgz#1aede831cb4ed4a398448df5a2c54b54a365644e"
-  integrity sha512-sMl7OSv0AvMOqn1UJ6j1unPMIHRXen0Ita1ujnMX912rrOcawe4f7wu0Zt9GIQhBhJvH2BaibqFgQ3lP+Pj2hA==
-  dependencies:
-    pretty-format "^24.3.0"
-
-"@types/testing-library__react@^9.1.2":
-  version "9.1.3"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__react/-/testing-library__react-9.1.3.tgz#35eca61cc6ea923543796f16034882a1603d7302"
-  integrity sha512-iCdNPKU3IsYwRK9JieSYAiX0+aYDXOGAmrC/3/M7AqqSDKnWWVv07X+Zk1uFSL7cMTUYzv4lQRfohucEocn5/w==
-  dependencies:
-    "@types/react-dom" "*"
-    "@types/testing-library__dom" "*"
-    pretty-format "^25.1.0"
 
 "@types/underscore@^1.10.11":
   version "1.10.11"
@@ -2399,11 +2360,6 @@ ansi-regex@^5.0.0:
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
-ansi-regex@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
-  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
-
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
@@ -2430,11 +2386,6 @@ ansi-styles@^4.1.0:
   dependencies:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
-
-ansi-styles@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
-  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -2464,13 +2415,6 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
-  integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
-  dependencies:
-    dequal "^2.0.3"
-
 aria-query@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz"
@@ -2479,7 +2423,7 @@ aria-query@^3.0.0:
     ast-types-flow "0.0.7"
     commander "^2.11.0"
 
-aria-query@^4.0.2:
+aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
   integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
@@ -3409,6 +3353,14 @@ chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz"
   integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^4.0.0, chalk@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -4367,11 +4319,6 @@ depd@~1.1.2:
   resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
-dequal@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
-  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
-
 des.js@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz"
@@ -4472,12 +4419,7 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-accessibility-api@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz#511e5993dd673b97c87ea47dba0e3892f7e0c983"
-  integrity sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==
-
-dom-accessibility-api@^0.5.9:
+dom-accessibility-api@^0.5.6:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
   integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
@@ -7668,7 +7610,7 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-lz-string@^1.5.0:
+lz-string@^1.4.4:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
   integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
@@ -8799,7 +8741,7 @@ performance-now@^2.1.0:
   resolved "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picocolors@1.1.1, picocolors@^1.0.0, picocolors@^1.1.0, picocolors@^1.1.1:
+picocolors@^1.0.0, picocolors@^1.1.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -9605,7 +9547,7 @@ pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
-pretty-format@^24.0.0, pretty-format@^24.3.0, pretty-format@^24.9.0:
+pretty-format@^24.0.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -9615,23 +9557,14 @@ pretty-format@^24.0.0, pretty-format@^24.3.0, pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
-pretty-format@^25.1.0:
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
-  integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
+pretty-format@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
+  integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
   dependencies:
-    "@jest/types" "^25.5.0"
+    "@jest/types" "^26.6.2"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
-    react-is "^16.12.0"
-
-pretty-format@^27.0.2:
-  version "27.5.1"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
-  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
-  dependencies:
-    ansi-regex "^5.0.1"
-    ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
 private@^0.1.8:
@@ -9970,7 +9903,7 @@ react-hook-form@^6.5.3:
   resolved "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.5.3.tgz"
   integrity sha512-ID0z1udMQueWta3cceQUBaWLqZZLwSNWkxXYcuxa0nbII+mnggmGiEQW7PuWBBkEXv6GdHlu4PNqRj/FoeDpRg==
 
-react-is@^16.12.0, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
+react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -12223,11 +12156,6 @@ w3c-xmlserializer@^1.1.2:
     domexception "^1.0.1"
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
-
-wait-for-expect@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
-  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
When reCAPTCHA fails to load (e.g. blocked by an ad blocker or network issue), the correct-abstract form silently swallowed the error — the modal closed with no feedback to the user.

- Move `await execute()` inside the try/catch in SubmitCorrectAbstract/FormPreview so reCAPTCHA rejections are caught like any other submission error
- Make `SubmissionState` error variant's `code` field optional so string-only rejections (no HTTP status) are representable
- Update FormStatus to branch on reCAPTCHA errors with a friendly "security check" message, and on all error paths render a copyable diff block so users can email adshelp@cfa.harvard.edu as a fallback
- Add @testing-library/react component tests covering the reCAPTCHA failure path and FormStatus rendering
- Add tsconfig.build.json to exclude test files from the rollup type-check pass