### PR TITLE
feat: capture specific feedback form data to Sentry before recaptcha

### DIFF
--- a/src/components/FeedbackForms/AssociatedReferences/FormPreview.tsx
+++ b/src/components/FeedbackForms/AssociatedReferences/FormPreview.tsx
@@ -7,6 +7,7 @@ import { PreviewModal } from '../components';
 import { AssociatedArticlesFormValues } from '../models';
 import PreviewBody from './PreviewBody';
 import { useRecaptcha } from '../../../hooks/useRecaptcha';
+import { sendFeedbackToSentry } from '../../../utils/sentryFeedback';
 
 const fetchBibcodes = ([bibcodes]: [string[]]) => {
   return apiFetch({
@@ -86,6 +87,20 @@ const FormPreview: React.FunctionComponent<IFormPreview> = ({ onSubmit }) => {
   };
 
   const handleSubmit = useCallback(async () => {
+    const values = getValues();
+    sendFeedbackToSentry({
+      formName: 'associated',
+      subject: 'Associated Articles',
+      name: values.name,
+      email: values.email,
+      data: {
+        sourceBibcode: values.sourceBibcode,
+        targets: values.associated.map((a) => a.bibcode),
+        relation: values.relation,
+        customRelation: values.customRelation,
+      },
+    });
+
     setRecaptchaError(null);
     setIsSubmitting(true);
     let recaptchaToken: string;

--- a/src/components/FeedbackForms/MissingIncorrectRecord/FormPreview.tsx
+++ b/src/components/FeedbackForms/MissingIncorrectRecord/FormPreview.tsx
@@ -8,6 +8,7 @@ import {MissingIncorrectRecordFormValues} from '../models';
 import {defaultValues} from './MissingIncorrectRecord';
 import PreviewBody, {fetchReference} from './PreviewBody';
 import {useRecaptcha} from '../../../hooks/useRecaptcha';
+import {sendFeedbackToSentry} from '../../../utils/sentryFeedback';
 
 const fetchBibcodes = ([bibcodes]: [string[]]) => {
   return apiFetch({
@@ -109,6 +110,20 @@ const FormPreview: React.FunctionComponent<IFormPreview> = ({onSubmit}) => {
   }, [isFulfilled]);
 
   const handleSubmit = async () => {
+    const values = getValues();
+    sendFeedbackToSentry({
+      formName: 'missing_incorrect_record',
+      subject: 'Missing References',
+      name: values.name,
+      email: values.email,
+      data: {
+        bibcodes: values.bibcodes.map(({citing, cited}) => ({
+          citing: citing.trim(),
+          cited: cited.trim(),
+        })),
+      },
+    });
+
     setRecaptchaError(null);
     setIsSubmitting(true);
     let recaptchaToken: string;

--- a/src/components/FeedbackForms/SubmitCorrectAbstract/FormPreview.tsx
+++ b/src/components/FeedbackForms/SubmitCorrectAbstract/FormPreview.tsx
@@ -7,6 +7,7 @@ import {createDiffString, ProcessedFormValues, processTree} from './DiffView';
 import PreviewBody from './PreviewBody';
 import {defaultValues, FormSubmissionCtx, OriginCtx} from './SubmitCorrectAbstract';
 import {useRecaptcha} from '../../../hooks/useRecaptcha';
+import {sendFeedbackToSentry} from '../../../utils/sentryFeedback';
 
 type FeedbackRequest = {
   original: ProcessedFormValues;
@@ -71,6 +72,23 @@ const FormPreview: React.FunctionComponent<IFormPreview> = ({
   const {setSubmissionState} = React.useContext(FormSubmissionCtx);
 
   const handleSubmit = async () => {
+    const formValues = getValues();
+    sendFeedbackToSentry({
+      formName: 'submit_correct_abstract',
+      subject: `${formValues.entryType === EntryType.Edit
+        ? 'Updated' : 'New'} Record`,
+      name: formValues.name,
+      email: formValues.email,
+      data: {
+        entryType: formValues.entryType,
+        bibcode: formValues.bibcode,
+        origin: origin ? {
+          bibcode: origin.bibcode,
+          title: origin.title,
+        } : undefined,
+      },
+    });
+
     setSubmissionState({status: 'pending'});
     setRecaptchaError(null);
     setIsSubmitting(true);

--- a/src/utils/sentryFeedback.ts
+++ b/src/utils/sentryFeedback.ts
@@ -1,0 +1,79 @@
+interface SentryFeedbackPayload {
+  formName: string;
+  subject: string;
+  name: string;
+  email: string;
+  data: Record<string, unknown>;
+}
+
+/**
+ * Sends structured feedback data to Sentry before the recaptcha/API
+ * submission attempt, so user data is captured even when recaptcha is
+ * blocked or the submission fails.
+ *
+ * Fire-and-forget — never throws, never blocks the form flow.
+ */
+export const sendFeedbackToSentry = (payload: SentryFeedbackPayload): void => {
+  try {
+    const { formName, subject, name, email, data } = payload;
+
+    const whenReady =
+      typeof (window as any).whenSentryReady === 'function'
+        ? (window as any).whenSentryReady()
+        : typeof (window as any).Sentry !== 'undefined'
+          ? Promise.resolve((window as any).Sentry)
+          : null;
+
+    if (!whenReady) {
+      return;
+    }
+
+    const sentryPayload = {
+      message: `${subject} feedback from ${name || 'anonymous'}`,
+      source: 'specific-feedback-form',
+      url: window.location.href,
+      tags: {
+        feedback_type: formName,
+        source: 'specific-feedback-form',
+      },
+      ...(name ? { name } : {}),
+      ...(email ? { email } : {}),
+    };
+
+    const captureContext = {
+      tags: {
+        feedback_type: formName,
+        source: 'specific-feedback-form',
+      },
+      extra: {
+        userAgent: navigator.userAgent,
+        formData: data,
+      },
+    };
+
+    whenReady
+      .then((sentry: any) => {
+        if (!sentry) {
+          return;
+        }
+
+        if (typeof sentry.captureFeedback === 'function') {
+          try {
+            sentry.captureFeedback(sentryPayload, { captureContext });
+          } catch (_) {}
+        } else if (typeof sentry.sendFeedback === 'function') {
+          try {
+            const result = sentry.sendFeedback(sentryPayload, {
+              captureContext,
+            });
+            if (result && typeof result.catch === 'function') {
+              result.catch(() => {});
+            }
+          } catch (_) {}
+        }
+      })
+      .catch(() => {});
+  } catch (_) {
+    // fire-and-forget
+  }
+};


### PR DESCRIPTION
When recaptcha is blocked (ad blockers, network restrictions, timeouts),
the specific feedback forms (associated articles, missing references,
correct abstract) show an error and the user's work is lost. The general
feedback form already mirrors every submission to Sentry via
captureFeedback — this replicates that pattern for the three specific
forms so no submission data is ever lost.

- Added shared sendFeedbackToSentry utility in src/utils/sentryFeedback.ts
  that resolves Sentry via whenSentryReady/window.Sentry and calls
  captureFeedback with sendFeedback fallback (same dual-path as navbar)
- Each FormPreview (AssociatedReferences, MissingIncorrectRecord,
  SubmitCorrectAbstract) now calls sendFeedbackToSentry as the first
  action in handleSubmit, before recaptcha attempt
- Fire-and-forget: fully try/catch wrapped, never blocks form flow
- Existing recaptcha-error captureMessage blocks left as-is (they track
  recaptcha failures specifically, the new utility captures user data)